### PR TITLE
fixed error in reward logging

### DIFF
--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -8,10 +8,7 @@ on:
     branches:
       - main
 
-permissions:
-  contents: write
-  pull-requests: write
-  actions: write
+permissions: write-all
 
 jobs:
   auto-release:

--- a/rewardgym/psychopy_render/stimuli.py
+++ b/rewardgym/psychopy_render/stimuli.py
@@ -622,15 +622,15 @@ class FeedBackStimulus(BaseStimulus):
         else:
             feedback_img = "zero"
 
-        reward = f"+{reward:5.1f}" if reward > 0 else f"{reward:5.1f}"
+        reward_outcome = f"+{reward:5.1f}" if reward > 0 else f"{reward:5.1f}"
 
-        total_reward = (
+        total_reward_outcome = (
             f"+{total_reward:5.1f}" if total_reward > 0 else f"{total_reward:5.1f}"
         )
 
-        reward_stage2 = "Total: " + total_reward
+        reward_stage2 = "Total: " + total_reward_outcome
 
-        self.textStim.setText(self.text.format(reward))
+        self.textStim.setText(self.text.format(reward_outcome))
         self.textStim2.setAutoDraw(False)
 
         stim_onset = logger.get_time()


### PR DESCRIPTION
There was a small bug in logging rewards - not logging the integer reward, but the string displayed on the screen. 
Fixed here.

## Proposed Changes
  - Changed the logging, to use temporary variable for displayed reward.
  - Changed permissions for auto, to write-all.

## Change Type
<!-- Indicate the type of change you think your pull request is -->
- [x] `bugfix` (+0.0.1)
- [ ] `minor` (+0.1.0)
- [ ] `major`  (+1.0.0)
- [ ] `refactoring` (no version update)
- [ ] `test` (no version update)
- [x] `infrastructure` (no version update)
- [ ] `documentation` (no version update)
- [ ] `other`

## Checklist before review
- [ ] I added everything I wanted to add to this PR.
- [ ] \[Code or tests only\] I wrote/updated the necessary docstrings.
- [ ] \[Code or tests only\] I ran and passed tests locally.
- [ ] \[Documentation only\] I built the docs locally.
- [ ] My contribution is harmonious with the rest of the code: I'm not introducing repetitions.
- [ ] My code respects the adopted style, especially linting conventions.
- [ ] The title of this PR is explanatory on its own, enough to be understood as part of a changelog.
- [ ] I added or indicated the right labels.
