### PR TITLE
Added wrappers for RL-EAM models and other models for reaction time simulations.

### DIFF
--- a/rewardgym/agents/base_agent.py
+++ b/rewardgym/agents/base_agent.py
@@ -27,7 +27,7 @@ class ValenceQAgent:
             final_epsilon: The final epsilon value
             discount_factor: The discount factor for computing the Q-value
         """
-        self.q_values = np.zeros((state_space, action_space))
+        self.q_values = np.zeros((state_space, action_space)) + 1 / action_space
 
         self.n_states = state_space
         self.n_actions = action_space

--- a/rewardgym/agents/base_agent.py
+++ b/rewardgym/agents/base_agent.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import Tuple, Union
+from typing import List, Tuple, Union
 
 import numpy as np
 
@@ -7,6 +7,12 @@ from ..utils import check_seed
 
 
 class ValenceQAgent:
+    """
+    A reinforcement learning agent implementing a Valence-based Q-learning algorithm.
+    The agent maintains state-action values (Q-values) and updates them using different
+    learning rates for positive and negative temporal differences.
+    """
+
     def __init__(
         self,
         learning_rate_pos: float,
@@ -17,16 +23,27 @@ class ValenceQAgent:
         state_space: int = 2,
         seed: Union[int, np.random.Generator] = 1000,
     ):
-        """Initialize a Reinforcement Learning agent with an empty dictionary
-        of state-action values (q_values), a learning rate and an epsilon.
-
-        Args:
-            learning_rate: The learning rate
-            initial_epsilon: The initial epsilon value
-            epsilon_decay: The decay for epsilon
-            final_epsilon: The final epsilon value
-            discount_factor: The discount factor for computing the Q-value
         """
+        Initializes the ValenceQAgent with parameters for learning, exploration, and environment size.
+
+        Parameters
+        ----------
+        learning_rate_pos : float
+            The learning rate used for updating Q-values when the temporal difference is positive.
+        learning_rate_neg : float
+            The learning rate used for updating Q-values when the temporal difference is negative.
+        temperature : float
+            The softmax temperature controlling exploration during action selection.
+        discount_factor : float, optional
+            The discount factor for future rewards, by default 0.99.
+        action_space : int, optional
+            The number of actions available in the environment, by default 2.
+        state_space : int, optional
+            The number of states in the environment, by default 2.
+        seed : Union[int, np.random.Generator], optional
+            Seed or random number generator for reproducibility, by default 1000.
+        """
+
         self.q_values = np.zeros((state_space, action_space)) + 1 / action_space
 
         self.n_states = state_space
@@ -41,12 +58,22 @@ class ValenceQAgent:
 
         self.training_error = []
 
-    def get_action(self, obs: Tuple[int, int, bool], avail_actions: list = None) -> int:
+    def get_action(self, obs: Tuple[int, int, bool], avail_actions: List = None) -> int:
         """
-        Returns the best action with probability (1 - epsilon)
-        otherwise a random action with probability epsilon to ensure exploration.
+        Selects an action based on the current state observation using a softmax policy.
+
+        Parameters
+        ----------
+        obs : Tuple[int, int, bool]
+            The current state observation represented as a tuple.
+        avail_actions : list, optional
+            A list of available actions. If None, all actions are assumed available, by default None.
+
+        Returns
+        -------
+        int
+            The selected action index.
         """
-        # with probability epsilon return a random action to explore the environment
 
         prob = self.get_probs(obs, avail_actions)
 
@@ -54,7 +81,23 @@ class ValenceQAgent:
 
         return a
 
-    def get_probs(self, obs, avail_actions=None):
+    def get_probs(self, obs: Tuple[int, int, bool], avail_actions: List = None):
+        """
+        Computes the softmax probability distribution over actions based on Q-values.
+
+        Parameters
+        ----------
+        obs : Tuple[int, int, bool]
+            The current state observation represented as a tuple.
+        avail_actions : list, optional
+            A list of available actions. If None, all actions are assumed available, by default None.
+
+        Returns
+        -------
+        np.ndarray
+            A probability distribution over the available actions.
+        """
+
         prob = np.zeros_like(self.q_values[obs])
 
         if avail_actions is None:
@@ -81,7 +124,29 @@ class ValenceQAgent:
         terminated: bool,
         next_obs: Tuple[int, int, bool],
     ):
-        """Updates the Q-value of an action."""
+        """
+        Updates the Q-value for a given action taken in a particular state using a
+        valence-based learning rate (positive or negative) depending on the temporal difference.
+
+        Parameters
+        ----------
+        obs : Tuple[int, int, bool]
+            The current state observation represented as a tuple.
+        action : int
+            The action taken in the current state.
+        reward : float
+            The reward received after taking the action.
+        terminated : bool
+            Whether the episode has ended after this action.
+        next_obs : Tuple[int, int, bool]
+            The next state observation after taking the action.
+
+        Returns
+        -------
+        np.ndarray
+            The updated Q-value table.
+        """
+
         future_q_value = (not terminated) * np.max(self.q_values[next_obs])
 
         temporal_difference = (
@@ -108,15 +173,23 @@ class QAgent(ValenceQAgent):
         state_space: int = 2,
         seed: Union[int, np.random.Generator] = 1000,
     ):
-        """Initialize a Reinforcement Learning agent with an empty dictionary
-        of state-action values (q_values), a learning rate and an epsilon.
+        """
+        Initializes a QAgents with parameters for learning, exploration, and environment size.
 
-        Args:
-            learning_rate: The learning rate
-            initial_epsilon: The initial epsilon value
-            epsilon_decay: The decay for epsilon
-            final_epsilon: The final epsilon value
-            discount_factor: The discount factor for computing the Q-value
+        Parameters
+        ----------
+        learning_rate : float
+            The learning rate used for updating Q-values.
+        temperature : float
+            The softmax temperature controlling exploration during action selection.
+        discount_factor : float, optional
+            The discount factor for future rewards, by default 0.99.
+        action_space : int, optional
+            The number of actions available in the environment, by default 2.
+        state_space : int, optional
+            The number of states in the environment, by default 2.
+        seed : Union[int, np.random.Generator], optional
+            Seed or random number generator for reproducibility, by default 1000.
         """
 
         super().__init__(
@@ -177,15 +250,30 @@ class ValenceQAgent_eligibility(ValenceQAgent):
         state_space: int = 2,
         seed: Union[int, np.random.Generator] = 1000,
     ):
-        """Initialize a Reinforcement Learning agent with an empty dictionary
-        of state-action values (q_values), a learning rate and an epsilon.
+        """
+        Initializes the ValenceQAgent with eligibility traces, and
+        parameters for learning, exploration, and environment size.
 
-        Args:
-            learning_rate: The learning rate
-            initial_epsilon: The initial epsilon value
-            epsilon_decay: The decay for epsilon
-            final_epsilon: The final epsilon value
-            discount_factor: The discount factor for computing the Q-value
+        Parameters
+        ----------
+        learning_rate_pos : float
+            The learning rate used for updating Q-values when the temporal difference is positive.
+        learning_rate_neg : float
+            The learning rate used for updating Q-values when the temporal difference is negative.
+        temperature : float
+            The softmax temperature controlling exploration during action selection.
+        discount_factor : float, optional
+            The discount factor for future rewards, by default 0.99.
+        eligibility_decay : float, optional
+            The decay rate of the eligibility traces, by default 0.0.
+        reset_traces : bool, optional
+            Whether to reset the eligibility traces each episode or not, by default True.
+        action_space : int, optional
+            The number of actions available in the environment, by default 2.
+        state_space : int, optional
+            The number of states in the environment, by default 2.
+        seed : Union[int, np.random.Generator], optional
+            Seed or random number generator for reproducibility, by default 1000.
         """
 
         super().__init__(
@@ -251,15 +339,28 @@ class QAgent_eligibility(ValenceQAgent_eligibility):
         state_space: int = 2,
         seed: Union[int, np.random.Generator] = 1000,
     ):
-        """Initialize a Reinforcement Learning agent with an empty dictionary
-        of state-action values (q_values), a learning rate and an epsilon.
+        """
+        Initializes the QAgent with eligibility traces, and
+        parameters for learning, exploration, and environment size.
 
-        Args:
-            learning_rate: The learning rate
-            initial_epsilon: The initial epsilon value
-            epsilon_decay: The decay for epsilon
-            final_epsilon: The final epsilon value
-            discount_factor: The discount factor for computing the Q-value
+        Parameters
+        ----------
+        learning_rate : float
+            The learning rate used for updating Q-values.
+        temperature : float
+            The softmax temperature controlling exploration during action selection.
+        discount_factor : float, optional
+            The discount factor for future rewards, by default 0.99.
+        eligibility_decay : float, optional
+            The decay rate of the eligibility traces, by default 0.0.
+        reset_traces : bool, optional
+            Whether to reset the eligibility traces each episode or not, by default True.
+        action_space : int, optional
+            The number of actions available in the environment, by default 2.
+        state_space : int, optional
+            The number of states in the environment, by default 2.
+        seed : Union[int, np.random.Generator], optional
+            Seed or random number generator for reproducibility, by default 1000.
         """
 
         super().__init__(

--- a/rewardgym/agents/modelbased_agents.py
+++ b/rewardgym/agents/modelbased_agents.py
@@ -9,6 +9,13 @@ from .base_agent import QAgent_eligibility, ValenceQAgent, ValenceQAgent_eligibi
 
 
 class HybridAgent(ValenceQAgent):
+    """
+    A hybrid reinforcement learning agent combining model-based (MB) and model-free (MF) learning.
+    The agent maintains a state-action transition table for model-based learning and a Q-value
+    table for model-free learning. The combination is controlled by a hybrid parameter that blends
+    the two approaches.
+    """
+
     def __init__(
         self,
         learning_rate_mb: float,
@@ -24,15 +31,39 @@ class HybridAgent(ValenceQAgent):
         graph=None,
         use_fixed=False,
     ):
-        """Initialize a Reinforcement Learning agent with an empty dictionary
-        of state-action values (q_values), a learning rate and an epsilon.
+        """
+        Initializes the HybridAgent with parameters for both model-based and model-free learning.
+        The agent maintains both state-action Q-values and state-action-state transition probabilities.
 
-        Args:
-            learning_rate: The learning rate
-            initial_epsilon: The initial epsilon value
-            epsilon_decay: The decay for epsilon
-            final_epsilon: The final epsilon value
-            discount_factor: The discount factor for computing the Q-value
+        Parameters
+        ----------
+        learning_rate_mb : float
+            The learning rate for updating the state-action-state transition model (model-based learning).
+        learning_rate_mf : Union[float, List]
+            The learning rate(s) for model-free learning. Can be a single float or a list with two values
+            for positive and negative learning rates (if using valence-based Q-learning).
+        temperature : float
+            The softmax temperature used to control exploration during action selection.
+        discount_factor : float, optional
+            The discount factor for future rewards, by default 0.99.
+        eligibility_decay : float, optional
+            The decay rate for eligibility traces in model-free learning, by default 0.0.
+        reset_traces : bool, optional
+            Whether to reset the eligibility traces after an episode, by default True.
+        hybrid : float, optional
+            A parameter that controls the balance between model-based (MB) and model-free (MF) learning,
+            by default 1.0 (fully MB).
+        action_space : int, optional
+            The number of actions available in the environment, by default 2.
+        state_space : int, optional
+            The number of states in the environment, by default 2.
+        seed : Union[int, np.random.Generator], optional
+            Seed or random number generator for reproducibility, by default 1000.
+        graph : dict, optional
+            A dictionary representing the environment's state-action transition graph. If None, transitions
+            are initialized randomly, by default None.
+        use_fixed : bool, optional
+            Whether to use fixed transition probabilities (based on a given graph), by default False.
         """
         self.t_values = np.zeros((state_space, action_space, state_space))
 
@@ -97,6 +128,22 @@ class HybridAgent(ValenceQAgent):
         self.training_error = []
 
     def get_probs(self, obs, avail_actions=None):
+        """
+        Computes the softmax probability distribution over actions based on a combination of
+        model-based (MB) and model-free (MF) Q-values, controlled by the hybrid parameter.
+
+        Parameters
+        ----------
+        obs : Tuple[int, int, bool]
+            The current state observation.
+        avail_actions : list, optional
+            A list of available actions. If None, all actions are considered available, by default None.
+
+        Returns
+        -------
+        np.ndarray
+            A probability distribution over the available actions.
+        """
         if avail_actions is None:
             avail_actions = np.arange(len(self.q_values[obs]))
 
@@ -126,6 +173,29 @@ class HybridAgent(ValenceQAgent):
         terminated: bool,
         next_obs: Tuple[int, int, bool],
     ):
+        """
+        Updates the Q-values for both model-based and model-free learning and updates
+        the state-action-state transition probabilities for model-based learning.
+
+        Parameters
+        ----------
+        obs : Tuple[int, int, bool]
+            The current state observation.
+        action : int
+            The action taken in the current state.
+        reward : float
+            The reward received after taking the action.
+        terminated : bool
+            Whether the episode has terminated.
+        next_obs : Tuple[int, int, bool]
+            The next state observation after taking the action.
+
+        Returns
+        -------
+        np.ndarray
+            The updated Q-value table.
+        """
+
         self.q_agent.update(obs, action, reward, terminated, next_obs)
 
         if not terminated:

--- a/rewardgym/agents/wrapper.py
+++ b/rewardgym/agents/wrapper.py
@@ -1,0 +1,133 @@
+from typing import Tuple
+
+import numpy as np
+
+
+class RTWrapper:
+    def __init__(self, agent, *args, **kwargs):
+        self.agent = agent(*args, **kwargs)
+
+    def __getattr__(self, name):
+        """
+        Delegate attribute access to the wrapped class instance.
+        This will be called if the attribute is not found in the wrapper itself.
+        """
+        return getattr(self.agent, name)
+
+
+class EAMWrapper(RTWrapper):
+    """
+    Wraps the action selection process of an agent with an evidence accumulation
+    process, returning both RTs and action. RL-EAM, following
+    Miletić, S., Boag, R. J., Trutti, A. C., Stevenson, N., Forstmann, B. U., & Heathcote, A. (2021).
+    A new model of decision processing in instrumental learning tasks. eLife, 10, e63055. https://doi.org/10.7554/eLife.63055
+    """
+
+    def __init__(
+        self,
+        agent,
+        *args,
+        eam_sd: float = 0.1,
+        eam_a: float = 1,
+        eam_dt: float = 0.01,
+        eam_v0: float = 0,
+        eam_w: float = 1.0,
+        add_error_process: bool = False,
+        **kwargs,
+    ):
+        self.agent = agent(*args, **kwargs)
+        self.eam_sd = eam_sd
+        self.eam_a = eam_a
+        self.eam_dt = eam_dt
+        self.eam_v0 = eam_v0
+        self.eam_w = eam_w
+        self.add_error_process = add_error_process
+
+    def get_rt_action(
+        self, obs: Tuple[int, int, bool], avail_actions: list = None
+    ) -> int:
+        """
+        Uses an evidence accumulation process to simulate reaction times and actions for a
+        given task. Creates a race-model where the agent's q-values determine the drift rate
+        of the evidence accumulation process.
+
+        Parameters
+        ----------
+        obs : Tuple[int, int, bool]
+            The agent's observation of the environment.
+        avail_actions : list, optional
+            List of available actions, by default None
+
+        Returns
+        -------
+        Tuple[int, float]
+            Returns the action and a reaction time.
+        """
+        if avail_actions is None:
+            avail_actions = np.arange(len(self.q_values[obs]))
+
+        qval = self.q_values[obs][avail_actions]
+
+        if self.add_error_process:
+            qval = np.hstack([qval, np.mean(qval)])
+
+        evidence = np.zeros_like(qval)
+        rts = 0
+
+        while all(evidence < self.eam_a):
+            evidence = self._accumulate(qval, evidence)
+            rts += self.eam_dt
+
+        a = np.argmax(evidence)
+
+        if a == len(qval) - 1 and self.add_error_process:
+            a = self.agent.rng.choice(len(avail_actions))
+
+        return a, rts
+
+    def _accumulate(self, q, evidence):
+        noise = self.agent.rng.normal(0, self.eam_sd, len(q))
+        evidence += (self.eam_v0 + self.eam_w * q) * self.eam_dt + noise * np.sqrt(
+            self.eam_dt
+        )
+
+        return evidence
+
+
+class SimpleWrapper(RTWrapper):
+    def __init__(self, agent, *args, rt_extra=0.0, env_name=None, **kwargs):
+        self.agent = agent(*args, **kwargs)
+        self.rt_extra = rt_extra
+        self.env_name = env_name
+
+    def get_rt_action(
+        self, obs: Tuple[int, int, bool], avail_actions: list = None
+    ) -> Tuple[int, float]:
+        """
+        Get's the softmax probability and uses it to chose an action, also using the
+        probability as a proxy for reaction times.
+
+        Parameters
+        ----------
+        obs : Tuple[int, int, bool]
+            The agent's observation of the environment.
+        avail_actions : list, optional
+            List of available actions, by default None
+
+        Returns
+        -------
+        Tuple[int, float]
+            Returns the action and a reaction time.
+        """
+
+        a = self.get_action(obs, avail_actions)
+        p = self.get_probs(obs, avail_actions)
+
+        if self.env_name == "gonogo":
+            rt_extra = a * self.rt_extra
+        else:
+            rt_extra = 0
+
+        rt = (1 - p[a]) / 2 + rt_extra
+
+        return a, rt

--- a/rewardgym/psychopy_core.py
+++ b/rewardgym/psychopy_core.py
@@ -69,7 +69,7 @@ def simple_rt_simulation(agent, env, obs, info):
     else:
         rt_extra = 0
 
-    return (1 - probs) / 2 + rt_extra
+    return key, (1 - probs) / 2 + rt_extra
 
 
 def run_task(
@@ -80,7 +80,6 @@ def run_task(
     seed=111,
     agent=None,
     n_episodes=None,
-    rt_function=simple_rt_simulation,
 ):
     if settings is None:
         settings = get_configs(env.name)(seed)
@@ -145,9 +144,10 @@ def run_task(
 
         while not done:
             if agent is not None:
-                # TODO Make this nicer
-                key = agent.get_action(obs, info["avail-actions"])
-                rt = rt_function(agent, env, obs, info)
+                if hasattr(agent, "get_rt_action") and callable(agent.get_rt_action):
+                    key, rt = agent.get_rt_action(obs, info["avail-actions"])
+                else:
+                    key, rt = simple_rt_simulation(agent, env, obs, info)
 
                 env.simulate_action(info, key, rt)
 

--- a/rewardgym/psychopy_render/stimuli.py
+++ b/rewardgym/psychopy_render/stimuli.py
@@ -429,9 +429,9 @@ class ActionStimulus(BaseStimulus):
         rt: float = None,
         **kwargs,
     ):
-        response_key, remaining = self._simulate_response(logger, key, rt)
+        response = self._simulate_response(logger, key, rt)
 
-        return response_key, remaining
+        return response
 
     def _simulate_response(self, logger, key, rt):
         response_key, rt = logger.key_strokes(key, rt)


### PR DESCRIPTION
This PR adds a wrapper class, so that evidence accumulation models can be added to the existing agent classes,
allowing thus for getting reaction times and actions using e.g. race models. 


## Proposed Changes
  - new module for reaction wrappers
  - adjusting existing code to accommodate 
  - adding more extensive doc strings to agent classes.
  - fixed an issue with RT and action simulations

## Change Type
<!-- Indicate the type of change you think your pull request is -->
- [ ] `bugfix` (+0.0.1)
- [x] `minor` (+0.1.0)
- [ ] `major`  (+1.0.0)
- [ ] `refactoring` (no version update)
- [ ] `test` (no version update)
- [ ] `infrastructure` (no version update)
- [ ] `documentation` (no version update)
- [ ] `other`

## Checklist before review
<!-- You're invited to open a draft PR ASAP, but before marking it "ready for review", check that you have done the following: -->
- [x] I added everything I wanted to add to this PR.
- [c] My contribution is harmonious with the rest of the code: I'm not introducing repetitions.
- [x] My code respects the adopted style, especially linting conventions.
- [x] The title of this PR is explanatory on its own, enough to be understood as part of a changelog.
- [x] I added or indicated the right labels.
