### PR TITLE
Display and instruction change up. Adapted Posner task.

### DIFF
--- a/assets/instructions/gonogo_instructions.py
+++ b/assets/instructions/gonogo_instructions.py
@@ -67,17 +67,9 @@ def gonogo_instructions():
             pos=(0, 150),
         )
 
-        part_3_1 = TextBox2(
-            win=win,
-            text=instructions["gonogo"]["3.1"],
-            letterHeight=28,
-            pos=(0, -150),
-        )
-
         img_fix = ImageStim(win=win, image=target, pos=(0, 0), size=target.shape[:2])
         img_fix.draw()
         part_3_0.draw()
-        part_3_1.draw()
 
     def part_4(win, instructions):
         part_4_0 = TextBox2(

--- a/assets/instructions/gonogo_instructions.py
+++ b/assets/instructions/gonogo_instructions.py
@@ -3,8 +3,10 @@ from psychopy.visual import ImageStim, TextBox2
 from rewardgym.psychopy_render.default_images import (
     fixation_cross,
     gonogo_probe,
+    lose_cross,
     make_card_stimulus,
     win_cross,
+    zero_cross,
 )
 
 
@@ -23,6 +25,16 @@ def gonogo_instructions():
         },
         height=350,
         width=350,
+    )
+
+    nothing = zero_cross(
+        width=100, height=100, circle_radius_inner=10, circle_radius_outer=15
+    )
+    winning = win_cross(
+        width=100, height=100, circle_radius_inner=10, circle_radius_outer=15
+    )
+    lose = lose_cross(
+        width=100, height=100, circle_radius_inner=10, circle_radius_outer=15
     )
 
     def part_0(win, instructions):
@@ -72,16 +84,49 @@ def gonogo_instructions():
         part_3_0.draw()
 
     def part_4(win, instructions):
-        part_4_0 = TextBox2(
+        start_pos = 280
+
+        start_pos -= 65
+
+        part_4_1 = TextBox2(
             win=win,
-            text=instructions["gonogo"]["4.0"],
+            text=instructions["gonogo"]["4.1"],
             letterHeight=28,
-            pos=(0, 150),
+            pos=(0, start_pos),
         )
 
-        img_fix = ImageStim(win=win, image=winning, pos=(0, 0), size=winning.shape[:2])
-        img_fix.draw()
-        part_4_0.draw()
+        start_pos -= 75
+        img2 = ImageStim(
+            win=win, image=winning, pos=(0, start_pos), size=winning.shape[:2]
+        )
+
+        start_pos -= 85
+
+        part_4_2 = TextBox2(
+            win=win,
+            text=instructions["gonogo"]["4.2"],
+            letterHeight=28,
+            pos=(0, start_pos),
+        )
+
+        start_pos -= 65
+        img3 = ImageStim(win=win, image=lose, pos=(0, start_pos), size=lose.shape[:2])
+
+        start_pos -= 85
+        part_4_3 = TextBox2(
+            win=win,
+            text=instructions["gonogo"]["4.3"],
+            letterHeight=28,
+            pos=(0, start_pos),
+        )
+
+        start_pos -= 65
+        img4 = ImageStim(
+            win=win, image=nothing, pos=(0, start_pos), size=nothing.shape[:2]
+        )
+
+        for ii in [part_4_1, part_4_2, part_4_3, img2, img3, img4]:
+            ii.draw()
 
     def part_5(win, instructions):
         part_5_0 = TextBox2(
@@ -91,5 +136,8 @@ def gonogo_instructions():
             alignment="center",
         )
         part_5_0.draw()
+
+        img_fix = ImageStim(win=win, image=target, pos=(0, -150), size=target.shape[:2])
+        img_fix.draw()
 
     return [part_0, part_1, part_2, part_3, part_4, part_5]

--- a/assets/instructions/instructions.py
+++ b/assets/instructions/instructions.py
@@ -2,7 +2,7 @@ import json
 import warnings
 
 from psychopy.event import waitKeys
-from psychopy.visual import TextStim
+from psychopy.visual import TextBox2
 
 from .gonogo_instructions import gonogo_instructions
 from .hcp_instructions import hcp_instructions
@@ -35,19 +35,19 @@ def show_instructions(task, win, key_map={"left": 0, "right": 1}):
         instructions = json.load(f)
 
     def end_screen(win, instructions):
-        end = TextStim(
+        end = TextBox2(
             win=win,
             text=instructions["instructions_end"],
-            height=28,
+            letterHeight=28,
             pos=(0, 0),
         )
         end.draw()
 
     def first_screen(win, instructions):
-        end = TextStim(
+        end = TextBox2(
             win=win,
             text=instructions["instructions"],
-            height=28,
+            letterHeight=28,
             pos=(0, 0),
         )
         end.draw()
@@ -67,9 +67,9 @@ def show_instructions(task, win, key_map={"left": 0, "right": 1}):
             outkey = waitKeys(keyList=list(key_map.keys()))[0]
 
             if slide_index == max_slide:
-                if key_map[outkey] == 0:
+                if key_map[outkey] == 1:
                     running = False
-                elif key_map[outkey] == 1:
+                elif key_map[outkey] == 0:
                     slide_index -= 1
 
             elif key_map[outkey] == 0:

--- a/assets/instructions/instructions_en.json
+++ b/assets/instructions/instructions_en.json
@@ -25,13 +25,20 @@
         "5.0": "Remember:\nWhen the outside of the diamond turns white you need to decide, whether to press LEFT or NOT?"
     },
     "two-step":{
-        "0.0": "In this game you will make a series of choices.\nFirst, you will be given two images to choose from.\nYour choice will take you to the second level.",
-        "1.0": "Your first choice will lead to another choice between two images. The images you see will depend on your first choice.",
-        "1.1": "Choosing an image in the second stage will sometimes earn you points and sometimes not. Some images are better than others, but which ones are better changes slowly during the experiment.",
-        "2.0": "The structure of the game is as follows:",
-        "2.1": "Each first-level choice has a 'preferred' second level. For example, if you choose the image with the cross, you'll usually see the blue (left) images, but sometimes you'll see the yellow images instead.\n",
-        "2.2": "This preference stays the same throughout the game.",
-        "3.0": "Remember:\nIn each trial you will have to make two choices.\nPress LEFT to select the image on the left.\nPress RIGHT to select the image on the right."
+        "0.0": "In this task there are four images.\nEach image can win you 1 point, bue each image has a different probability of winning.\nYour goal is to figure out, based on your experience, which image is mostly likely to give you a point.\n\nFor example, the images might have the following probabilities to win a point:",
+        "0.1": "50 %",
+        "0.2": "60 %",
+        "0.3": "70 %",
+        "0.4": "35 %",
+        "1.0": "You will get to choose between either these two images:",
+        "1.1": "Or these two images:",
+        "1.2": "Your choice sould be based on what you've learned about each image's probability of winning a point\nThe probabilities change slowly over time, so stay observant and adjust your choices accordingly.",
+        "2.0": "Before choosing between images, you'll first choose between two doors.\nEach door leads to a different pair of images.\nDoor 1 gives you a higher chance of seeing this pair:",
+        "2.1": "Door 2 gives you a higher chance of seeing this pair.",
+        "2.2": "In the real experiment, the doors and images will of course look differently.",
+        "3.0": "To summarize, the structure of the game looks as follow:",
+        "3.1": "First you pick a door: This determines which pair of images you will mostly likely see next.\n\nThen you choose which image you believe is most likely to win a point.",
+        "4.0": "Remember:\nPress LEFT to select the door or image on the left.\nPress RIGHT to select the door or image on the right."
     },
     "mid": {
         "0.0": "In this game you will see one of five images",

--- a/assets/instructions/instructions_en.json
+++ b/assets/instructions/instructions_en.json
@@ -1,27 +1,28 @@
 {
     "training": "You will now play a few practice rounds.\n\n",
-    "instructions": "You will now see the instructions for the next game.\nYou can press RIGHT to see the next instructions.\nYou can press LEFT to see the previous instructions.",
-    "instructions_perm": "Press LEFT for the previous, RIGHT for the next instructions.",
-    "instructions_end": "To start the game press LEFT. If you want to see the previous screen press RIGHT.",
-
+    "instructions": "You will now see the instructions for the next game.\n\nPress RIGHT to see next instructions.\nPress LEFT to see previous instructions.",
+    "instructions_perm": "Press LEFT to go back, RIGHT to proceed.",
+    "instructions_end": "To start the game press RIGHT. To review the instructions press LEFT.",
     "hcp": {
-        "0.0": "This is a game of chance.\nThink of it as drawing cards from a deck.\nThe cards have numbers from one to nine.\nFirst, you will see a question mark on the screen and you make a guess, then the card will be presented.\nYou must guess whether the number is LESS than or GREATER than five.",
-        "0.1": "Press LEFT to guess that the number is LESS than five.\nPress RIGHT to guess that the number will be GREATER than five.\nYou must answer while the question mark is on the screen.",
+        "0.0": "This is a game of chance.\nThink of it as drawing from a deck of cards.\nThe cards are numbered from one to nine.\nYou have to guess if the number you are about to see is LESS than or GREATER than five.",
+        "0.1": "Press LEFT to guess LESS than five.\nPress RIGHT to guess GREATER than five.\nYou must answer while the question mark is shown.",
         "1.0": "After you answer, the card will be shown.",
-        "1.1": "If you guessed correctly,\na green arrow appears in the fixation cross and you WIN 1 point.",
-        "1.2": "If not, a red arrow will appear and you LOSE 0.5 points.",
-        "1.3": "If the result is five, the fixation cross turns yellow and you gain nothing.",
+        "1.1": "If you guess correctly,\nthe diamond shape will go green and you WIN 1 point.",
+        "1.2": "If you guess incorrectly the dimaond shape will go red and you LOSE 0.5 points.",
+        "1.3": "If the card is five, the diamond shape goes yellow and your points don't change.",
         "1.4": "After each round, we shuffle the deck.",
         "2.0": "Remember:\nPress LEFT to guess the number is LESS less than five.\nPress RIGHT to guess the number is GREATER than five."
     },
     "gonogo": {
-        "0.0": "In this game, you have to figure out whether it's better to press LEFT or to not to press the LEFT.\nThere are some situations where it's better to press or not to press the LEFT.\nIn some situations you can WIN points, in other you can LOSE points.\n\n",
-        "0.1": "Each situation is introduced by one of four images.\nYou have to learn from experience whether it is better to press or not for each image.",
-        "1.0": "In each trial, you will see an image that introduces the situation:",
-        "2.0": "Then a fixation cross appears.",
-        "3.0": "When the fixation cross turns white you have to decide:\nDo you press LEFT or NOT?",
-        "4.0": "After a while you will get feedback if you made the right decision or not.",
-        "5.0": "Remember:\nWhen the cross flashes white you have to decide!\nDo you press LEFT or NOT?"
+        "0.0": "In this game, you have to figure out whether it's better to press LEFT or NOT.\nThere are some situations where it's better to press LEFT\n .. and in others it would be better NOT to press.\nIn some situations you will play to WIN points,\n in other you will play to avoid LOSING points.\n\n",
+        "0.1": "Each situation is signalled by one of four images.\nFor each image, you have to learn from experience if it is better to press LEFT or NOT",
+        "1.0": "On each trial, you will see an image like this that signals the situation:",
+        "2.0": "Then a diamond shape appears in the middle of the screen.",
+        "3.0": "When the outside turns white you need to decide, whether to press LEFT or NOT?",
+        "4.1": "If you win points, you wil see green.",
+        "4.2": "If you lose points you will see red.",
+        "4.3": "If your points don't change, you will see yellow.",
+        "5.0": "Remember:\nWhen the outside of the diamond turns white you need to decide, whether to press LEFT or NOT?"
     },
     "two-step":{
         "0.0": "In this game you will make a series of choices.\nFirst, you will be given two images to choose from.\nYour choice will take you to the second level.",
@@ -33,26 +34,27 @@
         "3.0": "Remember:\nIn each trial you will have to make two choices.\nPress LEFT to select the image on the left.\nPress RIGHT to select the image on the right."
     },
     "mid": {
-        "0.0": "In this game you will play with three shapes:",
-        "0.1": "The yellow squares mean you play to NOT LOSE points.\nThe pink circles mean you play to WIN points.\nThe triangle means nothing is at stake.",
+        "0.0": "In this game you will see one of five images",
+        "0.1": "In the middle of the image is how many points are at stake.\n You will see the image first, then you will see the diamond shape.\nAfter this you will se a black shape.\nWhen you see the black shape, you will need to press LEFT as fast as you can to win points or to avoid losing the points indicated by the image. ",
         "1.0": "The first thing that will happen in the game is one of these shapes will come up.\nAll you have to do is read the shapes to see if you play to WIN, to LOSE or if nothing is at stake.\nAfter the shape you will see a fixation cross.\nWhen you see the cross, you should just wait.",
         "2.0": "After the fixation there will always be a black shape that is the same shape as the one you just saw.\nYour job is to press LEFT when you see a black shape.",
         "2.1": "If you press to soon or do not press when the black shape is up, you will not receive the outcome for that shape.",
-        "3.0": "Remember:\n\nWhen you see a pink circle, you can WIN points.\n\nWhen you see a yellow square, you can LOSE points.\n\nWhen you see a blue triangle, there is nothing at stake.\n\nPress LEFT when you see the black shape to WIN or NOT LOSE."
+        "3.0": "Remember:\n\nWhen you see a pink circle, you can WIN points.\n\nWhen you see a yellow square, you can LOSE points.\n\nWhen you see a blue triangle, there is nothing at stake.\n\nPress LEFT when you see the black shape to WIN or AVOID LOSING indicated in the image."
     },
     "posner": {
-        "0.0": "In this game, you must respond to a target stimulus that briefly appears on either the left or the right side of the fixation cross.\nTo gain points, you must indicate the side on which the target appeared by pressing either LEFT or RIGHT.",
-        "1.0": "Before the target appears, an arrow will appear on either the left or the right side of the fixation cross.\nThe location arrow can help you predict, the side where the target will appear.\nThis game can be difficult, so pay attention to the cue.",
-        "2.0": "After the cue, the target will appear, on either left or right side and a distractor will appear on the opposite side. The target is a diamond, with the top or bottom corner is cut off.\nPress LEFT to indicate that the target appeared on the left.\nPress RIGHT to indicate that the target appeared on the right.",
-        "3.0": "Please try to focus on the fixation cross in the center of the screen for the entire game.\nTry not to move your eyes to the target stimulus.",
+        "0.0": "In this game, you must respond to a target stimulus that briefly appears on either the left or the right side of the diamond shape.\nTo gain points, you must indicate the side on which the target appeared by pressing LEFT or RIGHT.",
+        "1.0": "Before the target appears, an arrow will appear on either the left or the right side of the diamond.\nThe arrow can help you predict, the side where the target will appear next.\nThis game can be difficult, so pay attention to the arrow.",
+        "2.0": "The target is a diamond with a missing corner. After the arrow disappears, the target will appear, on either left or right.",
+        "2.1": "Another  shape will appear on the opposite side of the target.",
+        "2.2": "Press LEFT if the target was on the left.\nPress RIGHT if the target was on the right.",
+        "3.0": "Please try to focus on the diamond shape for the entire game.\nDo not move your eyes to the target.",
         "4.0": "Remember:\nPress LEFT to indicate that the target appeared on the left.\nPress RIGHT to indicate that the target appeared on the right.\n\nPlease respond as quickly and accurately as possible!"
     },
     "risk-sensitive":
     {
-        "0.0": "In this game you will see five different images and choose between them.\nEach image has a different value. Some images will always give you the same amount of points, some images will give you points with a 50% probability.",
-        "1.0": "In the game you will sometimes see a single image on the left or the right side of the screen. You must select this image. Pressing LEFT if it is on the left and RIGHT if it is on the right.\n",
-        "1.1": "These trials will help you to figure out the meaning of each image.",
-        "2.0": "In other trials you have to decide between two images.\nChoose in a way, that will earn you the most points.\nPress LEFT to select the image on the left.\nPress RIGHT to select the image on the right.",
+        "0.0": "In this game you will see five different images.\nEach image has a different value.\nSome images will always give you the same points, some images will give you points with 50% probability.",
+        "1.0": "You will sometimes see a single image on the left or the right side of the screen. You must select this image by pressing LEFT if it is on the left and RIGHT if it is on the right.\n",
+        "2.0": "Sometimes, you have to decide between two images.\nChoose in a way, that will earn you the most points.\nPress LEFT to select the image on the left.\nPress RIGHT to select the image on the right.",
         "3.0": "Remember:\nPress LEFT to select the image on the left.\nPress RIGHT to select the image on the right."
     }
 }

--- a/assets/instructions/instructions_en.json
+++ b/assets/instructions/instructions_en.json
@@ -21,7 +21,6 @@
         "1.0": "In each trial you will see an image introducing the situation:",
         "2.0": "Afterwards a fixation cross appears.",
         "3.0": "When the fixation cross turns white you have to decide:\nDo you press LEFT or NOT?",
-        "3.1": "For this instruction please press LEFT.",
         "4.0": "After a while you will get feedback if you made the correct decision or not.",
         "5.0": "Remember:\nWhen the cross flashes white you have to decide!\nDo you press LEFT or NOT?"
     },
@@ -43,10 +42,10 @@
         "3.0": "Remember:\n\nWhen you see a pink circle, you can WIN points.\n\nWhen you see a yellow square, you can LOSE points.\n\nWhen you see a blue triangle, there is nothing at stake.\n\nPress LEFT when you see the black shape to WIN or NOT LOSE."
     },
     "posner": {
-        "0.0": "In this game, you will need to respond to a stimulus appears briefly on either the left or the right side of the fixation cross.\nTo gain points, you will need to indicate the side the target appeared on using button presses.",
-        "1.0": "Before the target appears, there will be a dot on the top or the bottom of the fixation cross.\nThe location of the dot can help you predict, the side where the target will appear.\nThis game can be difficult, you should pay attention to the cue.",
-        "2.0": "After the cue, the target appears, on either left or right side.\nPress LEFT to indicate that the target appeared on the left.\nPress RIGHT to indicate that the target appeared on the right.",
-        "3.0": "There will be two breaks in the experiment.\nAfter each break the side each cue predicts changes, so you need to adapt you strategy.\nPlease try to focus on the fixation cross in the middle of the screen for the entire game.\nTry not to move your eyes to the target stimulus.",
+        "0.0": "In this game, you will need to respond to a target stimulus appears briefly on either the left or the right side of the fixation cross.\nTo gain points, you will need to indicate the side the target appeared on using button presses.",
+        "1.0": "Before the target appears, there an arrow appears on the left or the right side of the fixation cross.\nThe location arrow can help you predict, the side where the target will appear.\nThis game can be difficult, you should pay attention to the cue.",
+        "2.0": "After the cue, the target appears, on either left or right side and a distractor on the opposite side. The target is a diamond, where the top or bottom corner is cut off.\nPress LEFT to indicate that the target appeared on the left.\nPress RIGHT to indicate that the target appeared on the right.",
+        "3.0": "There will be one break in the experiment.\nPlease try to focus on the fixation cross in the middle of the screen for the entire game.\nTry not to move your eyes to the target stimulus.",
         "4.0": "Remember:\nPress LEFT to indicate that the target appeared on the left.\nPress RIGHT to indicate that the target appeared on the right.\n\nAnswer as fast and as accurate as possible!"
     },
     "risk-sensitive":

--- a/assets/instructions/instructions_en.json
+++ b/assets/instructions/instructions_en.json
@@ -36,7 +36,9 @@
     "mid": {
         "0.0": "In this game you will see one of five images",
         "0.1": "In the middle of the image is how many points are at stake.\n You will see the image first, then you will see the diamond shape.\nAfter this you will se a black shape.\nWhen you see the black shape, you will need to press LEFT as fast as you can to win points or to avoid losing the points indicated by the image. ",
-        "1.0": "The first thing that will happen in the game is one of these shapes will come up.\nAll you have to do is read the shapes to see if you play to WIN, to LOSE or if nothing is at stake.\nAfter the shape you will see a fixation cross.\nWhen you see the cross, you should just wait.",
+        "1.0": "So for example if you saw this image:",
+        "1.1": "then if you respond (press LEFT) to the black shape in time, you will receive 5 points.\n\nWhereas, if you see this image:",
+        "1.2": "then if you respond (press LEFT) to the black shape in time, you will avoid losing 5 points.",
         "2.0": "After the fixation there will always be a black shape that is the same shape as the one you just saw.\nYour job is to press LEFT when you see a black shape.",
         "2.1": "If you press to soon or do not press when the black shape is up, you will not receive the outcome for that shape.",
         "3.0": "Remember:\n\nWhen you see a pink circle, you can WIN points.\n\nWhen you see a yellow square, you can LOSE points.\n\nWhen you see a blue triangle, there is nothing at stake.\n\nPress LEFT when you see the black shape to WIN or AVOID LOSING indicated in the image."

--- a/assets/instructions/instructions_en.json
+++ b/assets/instructions/instructions_en.json
@@ -5,33 +5,32 @@
     "instructions_end": "To start the game press LEFT. If you want to see the previous screen press RIGHT.",
 
     "hcp": {
-        "0.0": "This is a game of chance.\nThink about it like drawing cards from a deck.\nThe cards have numbers from one to nine.\nFirst, you will see a question mark on the screen and you make a guess, then the card will be presented.\nYou have to guess whether the number is LESS than or GREATER than five.",
-        "0.1": "Press LEFT to guess that the number will be LESS than five.\nPress RIGHT to guess that the number will be GREATER than five.\nYou must answer while the question mark is on the screen.",
+        "0.0": "This is a game of chance.\nThink of it as drawing cards from a deck.\nThe cards have numbers from one to nine.\nFirst, you will see a question mark on the screen and you make a guess, then the card will be presented.\nYou must guess whether the number is LESS than or GREATER than five.",
+        "0.1": "Press LEFT to guess that the number is LESS than five.\nPress RIGHT to guess that the number will be GREATER than five.\nYou must answer while the question mark is on the screen.",
         "1.0": "After you answer, the card will be shown.",
         "1.1": "If you guessed correctly,\na green arrow appears in the fixation cross and you WIN 1 point.",
-        "1.2": "If not, a red arrow will be displayed and you LOSE 0.5 points.",
-        "1.3": "If the result equals five, the fixation cross turns yellow and you gain nothing.",
-        "1.4": "After each round we shuffle the deck.",
-        "2.0": "Remember:\nPress LEFT to guess the number is LESS less than five.\nPress RIGHT to guess the number is GREATER than five.",
-        "3.0": "Great!\nIf you have any questions, it is now time to raise them."
+        "1.2": "If not, a red arrow will appear and you LOSE 0.5 points.",
+        "1.3": "If the result is five, the fixation cross turns yellow and you gain nothing.",
+        "1.4": "After each round, we shuffle the deck.",
+        "2.0": "Remember:\nPress LEFT to guess the number is LESS less than five.\nPress RIGHT to guess the number is GREATER than five."
     },
     "gonogo": {
-        "0.0": "In this game, you will need to figure out whether it's better to press the button or to not press the button.\nThere are some situations where it's better to press or not.\nIn some situations you can WIN points, in other you can LOSE points.\n\n",
-        "0.1": "Each situation is introduced by one of four images.\nYou have to learn from experience whether it is better to press or not for each image.\n\n\nPress LEFT to continue",
-        "1.0": "In each trial you will see an image introducing the situation:",
-        "2.0": "Afterwards a fixation cross appears.",
+        "0.0": "In this game, you have to figure out whether it's better to press LEFT or to not to press the LEFT.\nThere are some situations where it's better to press or not to press the LEFT.\nIn some situations you can WIN points, in other you can LOSE points.\n\n",
+        "0.1": "Each situation is introduced by one of four images.\nYou have to learn from experience whether it is better to press or not for each image.",
+        "1.0": "In each trial, you will see an image that introduces the situation:",
+        "2.0": "Then a fixation cross appears.",
         "3.0": "When the fixation cross turns white you have to decide:\nDo you press LEFT or NOT?",
-        "4.0": "After a while you will get feedback if you made the correct decision or not.",
+        "4.0": "After a while you will get feedback if you made the right decision or not.",
         "5.0": "Remember:\nWhen the cross flashes white you have to decide!\nDo you press LEFT or NOT?"
     },
     "two-step":{
-        "0.0": "In this game you will make a series of choices.\nFirst, you'll be given two images to choose from.\nYour pick will lead you to the second stage.",
-        "1.0": "Your first choice will lead to another decision between two images. The images you see depend on your first choice.",
-        "1.1": "Choosing an image in the second stage will sometimes earn you points or not. Some images are better than others, but which ones are better changes slowly throughout the experiment.",
-        "2.0": "The structure of the game looks like this:",
-        "2.1": "Each first-stage choice has a 'preferred' second stage. For example, if you pick the image with the cross, you'll usually see the blue (left) images, but sometimes you'll see the yellow images instead.\n",
-        "2.2": "This preference stays the same during the whole experiment.",
-        "3.0": "Remember:\nIn each trial you will need to make a sequence of two decisions.\nPress LEFT to select the image on the left.\nPress RIGHT to select the image on the right."
+        "0.0": "In this game you will make a series of choices.\nFirst, you will be given two images to choose from.\nYour choice will take you to the second level.",
+        "1.0": "Your first choice will lead to another choice between two images. The images you see will depend on your first choice.",
+        "1.1": "Choosing an image in the second stage will sometimes earn you points and sometimes not. Some images are better than others, but which ones are better changes slowly during the experiment.",
+        "2.0": "The structure of the game is as follows:",
+        "2.1": "Each first-level choice has a 'preferred' second level. For example, if you choose the image with the cross, you'll usually see the blue (left) images, but sometimes you'll see the yellow images instead.\n",
+        "2.2": "This preference stays the same throughout the game.",
+        "3.0": "Remember:\nIn each trial you will have to make two choices.\nPress LEFT to select the image on the left.\nPress RIGHT to select the image on the right."
     },
     "mid": {
         "0.0": "In this game you will play with three shapes:",
@@ -42,18 +41,18 @@
         "3.0": "Remember:\n\nWhen you see a pink circle, you can WIN points.\n\nWhen you see a yellow square, you can LOSE points.\n\nWhen you see a blue triangle, there is nothing at stake.\n\nPress LEFT when you see the black shape to WIN or NOT LOSE."
     },
     "posner": {
-        "0.0": "In this game, you will need to respond to a target stimulus appears briefly on either the left or the right side of the fixation cross.\nTo gain points, you will need to indicate the side the target appeared on using button presses.",
-        "1.0": "Before the target appears, there an arrow appears on the left or the right side of the fixation cross.\nThe location arrow can help you predict, the side where the target will appear.\nThis game can be difficult, you should pay attention to the cue.",
-        "2.0": "After the cue, the target appears, on either left or right side and a distractor on the opposite side. The target is a diamond, where the top or bottom corner is cut off.\nPress LEFT to indicate that the target appeared on the left.\nPress RIGHT to indicate that the target appeared on the right.",
-        "3.0": "There will be one break in the experiment.\nPlease try to focus on the fixation cross in the middle of the screen for the entire game.\nTry not to move your eyes to the target stimulus.",
-        "4.0": "Remember:\nPress LEFT to indicate that the target appeared on the left.\nPress RIGHT to indicate that the target appeared on the right.\n\nAnswer as fast and as accurate as possible!"
+        "0.0": "In this game, you must respond to a target stimulus that briefly appears on either the left or the right side of the fixation cross.\nTo gain points, you must indicate the side on which the target appeared by pressing either LEFT or RIGHT.",
+        "1.0": "Before the target appears, an arrow will appear on either the left or the right side of the fixation cross.\nThe location arrow can help you predict, the side where the target will appear.\nThis game can be difficult, so pay attention to the cue.",
+        "2.0": "After the cue, the target will appear, on either left or right side and a distractor will appear on the opposite side. The target is a diamond, with the top or bottom corner is cut off.\nPress LEFT to indicate that the target appeared on the left.\nPress RIGHT to indicate that the target appeared on the right.",
+        "3.0": "Please try to focus on the fixation cross in the center of the screen for the entire game.\nTry not to move your eyes to the target stimulus.",
+        "4.0": "Remember:\nPress LEFT to indicate that the target appeared on the left.\nPress RIGHT to indicate that the target appeared on the right.\n\nPlease respond as quickly and accurately as possible!"
     },
     "risk-sensitive":
     {
-        "0.0": "In this game you will see five different images and decide between them.\nEach image has a different value. Some images will always gain you the same amount of points, some images will give you points with 50% probability.",
-        "1.0": "In the game you will sometimes see a single image on the left or the right side of the screen. You will need to select this image. Pressing LEFT if it is on the left and RIGHT if it is on the right.\n",
+        "0.0": "In this game you will see five different images and choose between them.\nEach image has a different value. Some images will always give you the same amount of points, some images will give you points with a 50% probability.",
+        "1.0": "In the game you will sometimes see a single image on the left or the right side of the screen. You must select this image. Pressing LEFT if it is on the left and RIGHT if it is on the right.\n",
         "1.1": "These trials will help you to figure out the meaning of each image.",
-        "2.0": "In other trial you will need to decide between two images.\nChoose in a way, that will earn you the most points.\nPress LEFT to select the image on the left.\nPress RIGHT to select the image on the right.",
+        "2.0": "In other trials you have to decide between two images.\nChoose in a way, that will earn you the most points.\nPress LEFT to select the image on the left.\nPress RIGHT to select the image on the right.",
         "3.0": "Remember:\nPress LEFT to select the image on the left.\nPress RIGHT to select the image on the right."
     }
 }

--- a/assets/instructions/instructions_en.json
+++ b/assets/instructions/instructions_en.json
@@ -8,13 +8,13 @@
         "0.1": "Press LEFT to guess LESS than five.\nPress RIGHT to guess GREATER than five.\nYou must answer while the question mark is shown.",
         "1.0": "After you answer, the card will be shown.",
         "1.1": "If you guess correctly,\nthe diamond shape will go green and you WIN 1 point.",
-        "1.2": "If you guess incorrectly the dimaond shape will go red and you LOSE 0.5 points.",
+        "1.2": "If you guess incorrectly the diamond shape will go red and you LOSE 0.5 points.",
         "1.3": "If the card is five, the diamond shape goes yellow and your points don't change.",
         "1.4": "After each round, we shuffle the deck.",
         "2.0": "Remember:\nPress LEFT to guess the number is LESS less than five.\nPress RIGHT to guess the number is GREATER than five."
     },
     "gonogo": {
-        "0.0": "In this game, you have to figure out whether it's better to press LEFT or NOT.\nThere are some situations where it's better to press LEFT\n .. and in others it would be better NOT to press.\nIn some situations you will play to WIN points,\n in other you will play to avoid LOSING points.\n\n",
+        "0.0": "In this game, you have to figure out whether it's better to press LEFT or NOT.\nThere are some situations where it's better to press LEFT\n... and in others it would be better NOT to press.\nIn some situations you will play to WIN points,\nin other you will play to avoid LOSING points.\n\n",
         "0.1": "Each situation is signalled by one of four images.\nFor each image, you have to learn from experience if it is better to press LEFT or NOT",
         "1.0": "On each trial, you will see an image like this that signals the situation:",
         "2.0": "Then a diamond shape appears in the middle of the screen.",

--- a/assets/instructions/mid_instructions.py
+++ b/assets/instructions/mid_instructions.py
@@ -1,6 +1,6 @@
 from psychopy.visual import ImageStim, TextBox2
 
-from rewardgym.psychopy_render.default_images import fixation_cross, mid_stimuli
+from rewardgym.psychopy_render.default_images import mid_stimuli
 
 
 def mid_instructions():
@@ -25,32 +25,51 @@ def mid_instructions():
         ]
 
         stims = [
-            ImageStim(win=win, image=i, pos=(lp, 0), size=size)
+            ImageStim(win=win, image=i, pos=(lp, 75), size=size)
             for i, lp in zip(stims, left_pos)
         ]
         part_0_1 = TextBox2(
             win=win,
             text=instructions["mid"]["0.1"],
             letterHeight=28,
-            pos=(0, -200),
+            pos=(0, -150),
         )
 
         for ii in stims + [part_0_0, part_0_1]:
             ii.draw()
 
     def part_1(win, instructions):
-        fix = fixation_cross()
-
         part_1_0 = TextBox2(
             win=win,
             text=instructions["mid"]["1.0"],
             letterHeight=28,
-            pos=(0, 250),
+            pos=(0, 275),
+        )
+        size = (125, 125)
+
+        img1 = ImageStim(
+            win=win, image=mid_stimuli("+5", "circle"), size=size, pos=(0, 170)
         )
 
-        fix = ImageStim(win=win, image=fix, size=fix.shape[:2])
+        img2 = ImageStim(
+            win=win, image=mid_stimuli("-5", "square"), size=size, pos=(0, -125)
+        )
 
-        for i in [part_1_0, fix]:
+        part_1_1 = TextBox2(
+            win=win,
+            text=instructions["mid"]["1.1"],
+            letterHeight=28,
+            pos=(0, 20),
+        )
+
+        part_1_2 = TextBox2(
+            win=win,
+            text=instructions["mid"]["1.2"],
+            letterHeight=28,
+            pos=(0, -225),
+        )
+
+        for i in [part_1_0, part_1_1, part_1_2, img1, img2]:
             i.draw()
 
     def part_2(win, instructions, size=size):

--- a/assets/instructions/posner_instructions.py
+++ b/assets/instructions/posner_instructions.py
@@ -30,23 +30,25 @@ def posner_instructions():
             pos=(0, 250),
         )
 
-        cue_up = posner_cue(up=True)
-        cue_down = posner_cue(up=False)
+        cue_left = posner_cue(left=True)
+        cue_right = posner_cue(left=False)
 
-        cue_up_stim = ImageStim(
-            win=win, pos=(-200, 0), image=cue_up, size=cue_up.shape[:2]
+        cue_left_stim = ImageStim(
+            win=win, pos=(-200, 0), image=cue_left, size=cue_left.shape[:2]
         )
-        cue_down_stim = ImageStim(
-            win=win, pos=(200, 0), image=cue_down, size=cue_down.shape[:2]
+        cue_right_stim = ImageStim(
+            win=win, pos=(200, 0), image=cue_right, size=cue_right.shape[:2]
         )
 
-        for i in [part_1_0, cue_up_stim, cue_down_stim]:
+        for i in [part_1_0, cue_left_stim, cue_right_stim]:
             i.draw()
 
     def part_2(win, instructions):
-        pt = posner_target()
+        pt = posner_target(target=True)
         pt_left = ImageStim(win=win, pos=(-300, 0), image=pt, size=pt.shape[:2])
-        pt_right = ImageStim(win=win, pos=(300, 0), image=pt, size=pt.shape[:2])
+        pt_right = ImageStim(
+            win=win, pos=(300, 0), image=posner_target(target=False), size=pt.shape[:2]
+        )
 
         part_2_0 = TextBox2(
             win=win,

--- a/assets/instructions/posner_instructions.py
+++ b/assets/instructions/posner_instructions.py
@@ -45,19 +45,47 @@ def posner_instructions():
 
     def part_2(win, instructions):
         pt = posner_target(target=True)
-        pt_left = ImageStim(win=win, pos=(-300, 0), image=pt, size=pt.shape[:2])
+        pt_left = ImageStim(
+            win=win,
+            pos=(-300, 100),
+            image=posner_target(target=True),
+            size=pt.shape[:2],
+        )
         pt_right = ImageStim(
-            win=win, pos=(300, 0), image=posner_target(target=False), size=pt.shape[:2]
+            win=win,
+            pos=(300, 100),
+            image=posner_target(target=True)[::-1],
+            size=pt.shape[:2],
+        )
+
+        pt_dist = ImageStim(
+            win=win,
+            pos=(0, -125),
+            image=posner_target(target=False)[::-1],
+            size=pt.shape[:2],
         )
 
         part_2_0 = TextBox2(
             win=win,
             text=instructions["posner"]["2.0"],
             letterHeight=28,
-            pos=(0, 200),
+            pos=(0, 250),
+        )
+        part_2_1 = TextBox2(
+            win=win,
+            text=instructions["posner"]["2.1"],
+            letterHeight=28,
+            pos=(0, -10),
         )
 
-        for ii in [part_2_0, pt_left, pt_right]:
+        part_2_2 = TextBox2(
+            win=win,
+            text=instructions["posner"]["2.2"],
+            letterHeight=28,
+            pos=(0, -250),
+        )
+
+        for ii in [part_2_0, part_2_1, part_2_2, pt_left, pt_right, pt_dist]:
             ii.draw()
 
     def part_3(win, instructions):

--- a/assets/instructions/twostep_instructions.py
+++ b/assets/instructions/twostep_instructions.py
@@ -7,7 +7,7 @@ from rewardgym.psychopy_render.default_images import make_card_stimulus
 def twostep_instructions():
     card1 = make_card_stimulus(
         {
-            "num_tiles": (1, 1),
+            "num_tiles": (1, 2),
             "shapes": ["cross"],
             "shape_pattern": "alternating",
             "color_pattern": "alternating",
@@ -19,7 +19,7 @@ def twostep_instructions():
 
     card2 = make_card_stimulus(
         {
-            "num_tiles": (1, 1),
+            "num_tiles": (2, 1),
             "shapes": ["X"],
             "shape_pattern": "alternating",
             "color_pattern": "alternating",
@@ -191,8 +191,8 @@ def twostep_instructions():
         img_card3 = ImageStim(win=win, image=card5, pos=(-120, -100), size=size)
         img_card4 = ImageStim(win=win, image=card6, pos=(120, -100), size=size)
 
-        img_door1 = ImageStim(win=win, image=card1, pos=(-500, 100), size=(150, 100))
-        img_door2 = ImageStim(win=win, image=card2, pos=(-500, -50), size=(150, 100))
+        img_door1 = ImageStim(win=win, image=card1, pos=(-510, 90), size=(100, 150))
+        img_door2 = ImageStim(win=win, image=card2, pos=(-510, -80), size=(100, 150))
 
         for i in [
             img_card1,
@@ -213,7 +213,7 @@ def twostep_instructions():
             win=win,
             text=instructions["two-step"]["3.0"],
             letterHeight=28,
-            pos=(0, 325),
+            pos=(0, 350),
         )
 
         part_3_1 = TextBox2(
@@ -223,14 +223,14 @@ def twostep_instructions():
             pos=(0, -250),
         )
 
-        small_shape1 = np.array(card1.shape[:2]) // 2
-        small_shape2 = np.array(card4.shape[:2]) // 2
+        small_shape1 = np.array(card1.shape[:2])[::-1] // 2
+        small_shape2 = np.array(card4.shape[:2])[::-1] // 2
 
         img_card1 = ImageStim(
-            win=win, image=card1, pos=(-100, 150 + y_offset), size=small_shape1
+            win=win, image=card1, pos=(-100, 175 + y_offset), size=small_shape1
         )
         img_card2 = ImageStim(
-            win=win, image=card2, pos=(100, 150 + y_offset), size=small_shape1
+            win=win, image=card2, pos=(100, 175 + y_offset), size=small_shape1
         )
 
         img_card3 = ImageStim(

--- a/assets/instructions/twostep_instructions.py
+++ b/assets/instructions/twostep_instructions.py
@@ -1,12 +1,10 @@
 import numpy as np
 from psychopy.visual import ImageStim, Line, TextBox2
 
-from rewardgym.psychopy_render.default_images import fixation_cross, make_card_stimulus
+from rewardgym.psychopy_render.default_images import make_card_stimulus
 
 
 def twostep_instructions():
-    fix = fixation_cross()
-
     card1 = make_card_stimulus(
         {
             "num_tiles": (1, 1),
@@ -15,7 +13,7 @@ def twostep_instructions():
             "color_pattern": "alternating",
             "colors": ((200, 0, 0), (200, 0, 0)),
         },
-        height=250,
+        height=375,
         width=250,
     )
 
@@ -27,7 +25,7 @@ def twostep_instructions():
             "color_pattern": "alternating",
             "colors": ((200, 0, 0), (200, 0, 0)),
         },
-        height=250,
+        height=375,
         width=250,
     )
 
@@ -81,14 +79,55 @@ def twostep_instructions():
             win=win,
             text=instructions["two-step"]["0.0"],
             letterHeight=28,
-            pos=(0, 250),
+            pos=(0, 200),
         )
 
-        img_card1 = ImageStim(win=win, image=card1, pos=(-325, 0), size=card1.shape[:2])
-        img_card2 = ImageStim(win=win, image=card2, pos=(325, 0), size=card1.shape[:2])
-        fixation = ImageStim(win=win, image=fix, pos=(0, 0), size=fix.shape[:2])
+        size = (100, 100)
+        img_card1 = ImageStim(win=win, image=card3, pos=(-320, -60), size=size)
+        img_card2 = ImageStim(win=win, image=card4, pos=(-120, -60), size=size)
+        img_card3 = ImageStim(win=win, image=card5, pos=(120, -60), size=size)
+        img_card4 = ImageStim(win=win, image=card6, pos=(320, -60), size=size)
 
-        for i in [img_card1, img_card2, fixation, part_0_0]:
+        part_0_1 = TextBox2(
+            win=win,
+            text=instructions["two-step"]["0.1"],
+            letterHeight=28,
+            pos=(-320, -130),
+            size=(100, None),
+        )
+        part_0_2 = TextBox2(
+            win=win,
+            text=instructions["two-step"]["0.2"],
+            letterHeight=28,
+            pos=(-120, -130),
+            size=(100, None),
+        )
+        part_0_3 = TextBox2(
+            win=win,
+            text=instructions["two-step"]["0.3"],
+            letterHeight=28,
+            pos=(120, -130),
+            size=(100, None),
+        )
+        part_0_4 = TextBox2(
+            win=win,
+            text=instructions["two-step"]["0.4"],
+            letterHeight=28,
+            pos=(320, -130),
+            size=(100, None),
+        )
+
+        for i in [
+            img_card1,
+            img_card2,
+            img_card3,
+            img_card4,
+            part_0_0,
+            part_0_1,
+            part_0_2,
+            part_0_3,
+            part_0_4,
+        ]:
             i.draw()
 
     def part_1(win, instructions):
@@ -102,14 +141,29 @@ def twostep_instructions():
             win=win,
             text=instructions["two-step"]["1.1"],
             letterHeight=28,
-            pos=(0, -250),
+            pos=(0, 80),
         )
+        part_1_2 = TextBox2(
+            win=win,
+            text=instructions["two-step"]["1.2"],
+            letterHeight=28,
+            pos=(0, -175),
+        )
+        size = (100, 100)
+        img_card1 = ImageStim(win=win, image=card3, pos=(-120, 150), size=size)
+        img_card2 = ImageStim(win=win, image=card4, pos=(120, 150), size=size)
+        img_card3 = ImageStim(win=win, image=card5, pos=(-120, 0), size=size)
+        img_card4 = ImageStim(win=win, image=card6, pos=(120, 0), size=size)
 
-        fixation = ImageStim(win=win, image=fix, pos=(0, 0), size=fix.shape[:2])
-        img_card3 = ImageStim(win=win, image=card3, pos=(-325, 0), size=card1.shape[:2])
-        img_card4 = ImageStim(win=win, image=card4, pos=(325, 0), size=card1.shape[:2])
-
-        for i in [img_card3, img_card4, fixation, part_1_0, part_1_1]:
+        for i in [
+            img_card1,
+            img_card2,
+            img_card3,
+            img_card4,
+            part_1_0,
+            part_1_1,
+            part_1_2,
+        ]:
             i.draw()
 
     def part_2(win, instructions):
@@ -117,67 +171,109 @@ def twostep_instructions():
             win=win,
             text=instructions["two-step"]["2.0"],
             letterHeight=28,
+            pos=(0, 250),
+        )
+        part_2_1 = TextBox2(
+            win=win,
+            text=instructions["two-step"]["2.1"],
+            letterHeight=28,
+            pos=(0, -20),
+        )
+        part_2_2 = TextBox2(
+            win=win,
+            text=instructions["two-step"]["2.2"],
+            letterHeight=28,
+            pos=(0, -200),
+        )
+        size = (100, 100)
+        img_card1 = ImageStim(win=win, image=card3, pos=(-120, 50), size=size)
+        img_card2 = ImageStim(win=win, image=card4, pos=(120, 50), size=size)
+        img_card3 = ImageStim(win=win, image=card5, pos=(-120, -100), size=size)
+        img_card4 = ImageStim(win=win, image=card6, pos=(120, -100), size=size)
+
+        img_door1 = ImageStim(win=win, image=card1, pos=(-500, 100), size=(150, 100))
+        img_door2 = ImageStim(win=win, image=card2, pos=(-500, -50), size=(150, 100))
+
+        for i in [
+            img_card1,
+            img_card2,
+            img_card3,
+            img_card4,
+            part_2_0,
+            part_2_1,
+            part_2_2,
+            img_door1,
+            img_door2,
+        ]:
+            i.draw()
+
+    def part_3(win, instructions):
+        y_offset = 60
+        part_3_0 = TextBox2(
+            win=win,
+            text=instructions["two-step"]["3.0"],
+            letterHeight=28,
             pos=(0, 325),
         )
 
-        y_offset = 75
-        small_shape = np.array(card1.shape[:2]) // 2
+        part_3_1 = TextBox2(
+            win=win,
+            text=instructions["two-step"]["3.1"],
+            letterHeight=28,
+            pos=(0, -250),
+        )
+
+        small_shape1 = np.array(card1.shape[:2]) // 2
+        small_shape2 = np.array(card4.shape[:2]) // 2
 
         img_card1 = ImageStim(
-            win=win, image=card1, pos=(-75, 150 + y_offset), size=small_shape
+            win=win, image=card1, pos=(-100, 150 + y_offset), size=small_shape1
         )
         img_card2 = ImageStim(
-            win=win, image=card2, pos=(75, 150 + y_offset), size=small_shape
+            win=win, image=card2, pos=(100, 150 + y_offset), size=small_shape1
         )
 
         img_card3 = ImageStim(
-            win=win, image=card3, pos=(-300, -125 + y_offset), size=small_shape
+            win=win, image=card3, pos=(-320, -125 + y_offset), size=small_shape2
         )
         img_card4 = ImageStim(
-            win=win, image=card4, pos=(-150, -125 + y_offset), size=small_shape
+            win=win, image=card4, pos=(-150, -125 + y_offset), size=small_shape2
         )
 
         img_card5 = ImageStim(
-            win=win, image=card5, pos=(150, -125 + y_offset), size=small_shape
+            win=win, image=card5, pos=(150, -125 + y_offset), size=small_shape2
         )
         img_card6 = ImageStim(
-            win=win, image=card6, pos=(300, -125 + y_offset), size=small_shape
+            win=win, image=card6, pos=(320, -125 + y_offset), size=small_shape2
         )
 
         line1 = Line(
             win=win,
-            start=(-80, 70 + y_offset),
-            end=((-450) // 2 - 5, -60 + y_offset),
+            start=(-100, 70 + y_offset),
+            end=((-460) // 2 - 5, -55 + y_offset),
             lineWidth=20,
             color=[0.25, 0.25, 0.25],
         )
         line2 = Line(
             win=win,
-            start=(-70, 70 + y_offset),
-            end=((450) // 2 - 5, -60 + y_offset),
+            start=(-100, 70 + y_offset),
+            end=((440) // 2 - 5, -55 + y_offset),
             lineWidth=10,
             color=[0.25, 0.25, 0.25],
         )
         line3 = Line(
             win=win,
-            start=(70, 70 + y_offset),
-            end=((-450) // 2 + 5, -60 + y_offset),
+            start=(100, 70 + y_offset),
+            end=((-440) // 2 + 5, -55 + y_offset),
             lineWidth=10,
             color=[0.25, 0.25, 0.25],
         )
         line4 = Line(
             win=win,
-            start=(80, 70 + y_offset),
-            end=((450) // 2 + 5, -60 + y_offset),
+            start=(100, 70 + y_offset),
+            end=((460) // 2 + 5, -55 + y_offset),
             lineWidth=20,
             color=[0.25, 0.25, 0.25],
-        )
-
-        part_2_1 = TextBox2(
-            win=win,
-            text=instructions["two-step"]["2.1"] + instructions["two-step"]["2.2"],
-            letterHeight=28,
-            pos=(0, -250),
         )
 
         for i in [
@@ -191,18 +287,18 @@ def twostep_instructions():
             img_card4,
             img_card5,
             img_card6,
-            part_2_0,
-            part_2_1,
+            part_3_0,
+            part_3_1,
         ]:
             i.draw()
 
-    def part_3(win, instructions):
-        part_3_0 = TextBox2(
+    def part_4(win, instructions):
+        part_4_0 = TextBox2(
             win=win,
-            text=instructions["two-step"]["3.0"],
+            text=instructions["two-step"]["4.0"],
             letterHeight=28,
             pos=(0, 75),
         )
-        part_3_0.draw()
+        part_4_0.draw()
 
-    return [part_0, part_1, part_2, part_3]
+    return [part_0, part_1, part_2, part_3, part_4]

--- a/rewardgym/environments/psychopy_env.py
+++ b/rewardgym/environments/psychopy_env.py
@@ -59,7 +59,7 @@ class PsychopyEnv(BaseEnv):
             n_actions,
         )
 
-        self.issetup = False
+        self.is_setup = False
         self.action = False
 
     def setup(self, window=None, logger=None, expose_last_stim=False):
@@ -87,9 +87,13 @@ class PsychopyEnv(BaseEnv):
 
         for node in self.graph.keys():
             if "psychopy" in self.info_dict[node].keys():
-                [stim.setup(self.window) for stim in self.info_dict[node]["psychopy"]]
+                [
+                    stim.setup(self.window)
+                    for stim in self.info_dict[node]["psychopy"]
+                    if not stim.is_setup
+                ]
 
-        self.issetup = True
+        self.is_setup = True
 
     def _setup_simulation(self, window=None, logger=None, expose_last_stim=False):
         self.expose_last_stim = expose_last_stim
@@ -128,7 +132,7 @@ class PsychopyEnv(BaseEnv):
         )
 
         if self.render_mode == "psychopy" and "psychopy" in info.keys():
-            if not self.issetup:
+            if not self.is_setup:
                 raise RuntimeError(
                     "You have to setup the environment first, using env.setup_render()"
                 )

--- a/rewardgym/psychopy_render/default_images.py
+++ b/rewardgym/psychopy_render/default_images.py
@@ -365,17 +365,13 @@ def mid_stimuli(
     if not probe:
         offset = 4 if shape == "triangle_u" else 0
 
-        draw_shape(
+        draw_centered_shape(
             draw,
             shape,
-            [
-                border_width,
-                border_width,
-                shape_dim - border_width,
-                shape_dim - border_width + offset,
-            ],
-            stim_color,
-            0,
+            [0, 0, shape_dim, shape_dim + offset],
+            bbox_padding=border_width,
+            color=stim_color,
+            padding=0,
         )
 
         offset = 30 if shape == "triangle_u" else 0
@@ -393,6 +389,7 @@ def mid_stimuli(
 
     pattern = np.array(pattern) / 255
     pattern = pattern[::-1, :]
+
     return pattern
 
 
@@ -419,9 +416,9 @@ def posner_cue(
     )
 
     if left:
-        pattern = pattern.transpose(Image.ROTATE_90)
-    else:
         pattern = pattern.transpose(Image.ROTATE_270)
+    else:
+        pattern = pattern.transpose(Image.ROTATE_90)
 
     return np.array(pattern) / 255
 

--- a/rewardgym/psychopy_render/default_images.py
+++ b/rewardgym/psychopy_render/default_images.py
@@ -37,6 +37,19 @@ colors = [
 STIMULUS_DEFAULTS = {"shapes": shapes_perm, "colors": colors, "patterns": patterns}
 
 
+def draw_centered_shape(draw, shape_name, bbox, bbox_padding, color, padding=0):
+    padded_box = [
+        bbox[0] + bbox_padding,
+        bbox[1] + bbox_padding,
+        bbox[2] - bbox_padding,
+        bbox[3] - bbox_padding,
+    ]
+
+    draw_shape(
+        draw=draw, shape=shape_name, bbox=padded_box, color=color, padding=padding
+    )
+
+
 def fixation_cross(
     height=150,
     width=150,
@@ -52,37 +65,22 @@ def fixation_cross(
     center_y = height // 2
 
     draw_shape(draw, "diamond", [0, 0, height, width], (0, 0, 0), 0)
-    draw_shape(
-        draw,
-        "diamond",
-        [border_width, border_width, width - border_width, height - border_width],
-        color,
-        0,
+    draw_centered_shape(
+        draw, "diamond", [0, 0, height, width], border_width, color=color
     )
-
-    draw_shape(
+    draw_centered_shape(
         draw,
         "circle",
-        [
-            center_x - circle_radius_outer,
-            center_y - circle_radius_outer,
-            center_x + circle_radius_outer,
-            center_y + circle_radius_outer,
-        ],
-        (0, 0, 0),
-        0,
+        bbox=[center_x, center_y, center_x, center_y],
+        bbox_padding=-circle_radius_outer,
+        color=(0, 0, 0),
     )
-    draw_shape(
+    draw_centered_shape(
         draw,
         "neg-circle",
-        [
-            center_x - circle_radius_inner,
-            center_y - circle_radius_inner,
-            center_x + circle_radius_inner,
-            center_y + circle_radius_inner,
-        ],
-        (120, 0, 0),
-        0,
+        bbox=[center_x, center_y, center_x, center_y],
+        bbox_padding=-circle_radius_inner,
+        color=(120, 0, 0),
     )
 
     fix_cross = np.array(pattern) / 255
@@ -105,43 +103,27 @@ def win_cross(
     center_y = height // 2
 
     draw_shape(draw, "diamond", [0, 0, height, width], (0, 0, 0), 0)
-    draw_shape(
-        draw,
-        "diamond",
-        [border_width, border_width, width - border_width, height - border_width],
-        color,
-        0,
+    draw_centered_shape(
+        draw, "diamond", [0, 0, height, width], border_width, color=color
     )
 
-    draw_shape(
-        draw,
-        "halfdiamond_u",
-        [border_width, border_width, width - border_width, height - border_width],
-        cross_color,
+    draw_centered_shape(
+        draw, "halfdiamond_u", [0, 0, height, width], border_width, color=cross_color
     )
-    draw_shape(
+
+    draw_centered_shape(
         draw,
         "circle",
-        [
-            center_x - circle_radius_outer,
-            center_y - circle_radius_outer,
-            center_x + circle_radius_outer,
-            center_y + circle_radius_outer,
-        ],
-        (0, 0, 0),
-        0,
+        bbox=[center_x, center_y, center_x, center_y],
+        bbox_padding=-circle_radius_outer,
+        color=(0, 0, 0),
     )
-    draw_shape(
+    draw_centered_shape(
         draw,
         "neg-circle",
-        [
-            center_x - circle_radius_inner,
-            center_y - circle_radius_inner,
-            center_x + circle_radius_inner,
-            center_y + circle_radius_inner,
-        ],
-        (120, 0, 0),
-        0,
+        bbox=[center_x, center_y, center_x, center_y],
+        bbox_padding=-circle_radius_inner,
+        color=(120, 0, 0),
     )
     win_cross = np.array(pattern) / 255
 
@@ -164,43 +146,26 @@ def lose_cross(
     center_y = height // 2
 
     draw_shape(draw, "diamond", [0, 0, height, width], (0, 0, 0), 0)
-    draw_shape(
-        draw,
-        "diamond",
-        [border_width, border_width, width - border_width, height - border_width],
-        color,
-        0,
+    draw_centered_shape(
+        draw, "diamond", [0, 0, height, width], border_width, color=color
+    )
+    draw_centered_shape(
+        draw, "halfdiamond_u", [0, 0, height, width], border_width, color=cross_color
     )
 
-    draw_shape(
-        draw,
-        "halfdiamond_d",
-        [border_width, border_width, width - border_width, height - border_width],
-        cross_color,
-    )
-    draw_shape(
+    draw_centered_shape(
         draw,
         "circle",
-        [
-            center_x - circle_radius_outer,
-            center_y - circle_radius_outer,
-            center_x + circle_radius_outer,
-            center_y + circle_radius_outer,
-        ],
-        (0, 0, 0),
-        0,
+        bbox=[center_x, center_y, center_x, center_y],
+        bbox_padding=-circle_radius_outer,
+        color=(0, 0, 0),
     )
-    draw_shape(
+    draw_centered_shape(
         draw,
         "neg-circle",
-        [
-            center_x - circle_radius_inner,
-            center_y - circle_radius_inner,
-            center_x + circle_radius_inner,
-            center_y + circle_radius_inner,
-        ],
-        (120, 0, 0),
-        0,
+        bbox=[center_x, center_y, center_x, center_y],
+        bbox_padding=-circle_radius_inner,
+        color=(120, 0, 0),
     )
     lose_cross = np.array(pattern) / 255
 
@@ -223,12 +188,8 @@ def zero_cross(
     center_y = height // 2
 
     draw_shape(draw, "diamond", [0, 0, height, width], (0, 0, 0), 0)
-    draw_shape(
-        draw,
-        "diamond",
-        [border_width, border_width, width - border_width, height - border_width],
-        cross_color,
-        0,
+    draw_centered_shape(
+        draw, "diamond", [0, 0, height, width], border_width, color=cross_color
     )
 
     draw_shape(
@@ -260,29 +221,19 @@ def zero_cross(
         0,
     )
 
-    draw_shape(
+    draw_centered_shape(
         draw,
         "circle",
-        [
-            center_x - circle_radius_outer,
-            center_y - circle_radius_outer,
-            center_x + circle_radius_outer,
-            center_y + circle_radius_outer,
-        ],
-        (0, 0, 0),
-        0,
+        bbox=[center_x, center_y, center_x, center_y],
+        bbox_padding=-circle_radius_outer,
+        color=(0, 0, 0),
     )
-    draw_shape(
+    draw_centered_shape(
         draw,
         "neg-circle",
-        [
-            center_x - circle_radius_inner,
-            center_y - circle_radius_inner,
-            center_x + circle_radius_inner,
-            center_y + circle_radius_inner,
-        ],
-        (120, 0, 0),
-        0,
+        bbox=[center_x, center_y, center_x, center_y],
+        bbox_padding=-circle_radius_inner,
+        color=(120, 0, 0),
     )
 
     zero_cross = np.array(pattern) / 255
@@ -324,44 +275,28 @@ def gonogo_probe(
         (0, 0, 0),
         0,
     )
-    draw_shape(
+    draw_centered_shape(
         draw,
         "diamond",
-        [
-            border_width + outer_border,
-            border_width + outer_border,
-            outer_border + width - border_width,
-            outer_border + height - border_width,
-        ],
-        color,
-        0,
+        bbox=[outer_border, outer_border, width + outer_border, height + outer_border],
+        bbox_padding=border_width,
+        color=color,
     )
 
-    draw_shape(
+    draw_centered_shape(
         draw,
         "circle",
-        [
-            center_x - circle_radius_outer,
-            center_y - circle_radius_outer,
-            center_x + circle_radius_outer,
-            center_y + circle_radius_outer,
-        ],
-        (0, 0, 0),
-        0,
+        bbox=[center_x, center_y, center_x, center_y],
+        bbox_padding=-circle_radius_outer,
+        color=(0, 0, 0),
     )
-    draw_shape(
+    draw_centered_shape(
         draw,
         "neg-circle",
-        [
-            center_x - circle_radius_inner,
-            center_y - circle_radius_inner,
-            center_x + circle_radius_inner,
-            center_y + circle_radius_inner,
-        ],
-        (120, 0, 0),
-        0,
+        bbox=[center_x, center_y, center_x, center_y],
+        bbox_padding=-circle_radius_inner,
+        color=(120, 0, 0),
     )
-
     probe = np.array(pattern) / 255
 
     return probe
@@ -495,105 +430,77 @@ def posner_cue(
     border_width=10,
     circle_radius_outer=20,
     circle_radius_inner=15,
-    cue_outer_radius=20,
-    cue_inner_width=10,
-    up=True,
+    outer_border=10,
+    left=True,
 ):
+    actual_height = height + outer_border * 2
+    actual_width = width + outer_border * 2
+
     pattern = Image.new(
-        "RGBA", (width + 1, height + 2 * cue_outer_radius + 1), (0, 0, 0, 0)
+        "RGBA",
+        (actual_height + 1, actual_width + 1),
+        (0, 0, 0, 0),
     )
     draw = ImageDraw.Draw(pattern)
 
-    center_x = width // 2
-    center_y = (height + 2 * cue_outer_radius) // 2
+    center_x = actual_width // 2
+    center_y = actual_height // 2
+
+    draw_shape(
+        draw,
+        "halfdiamond_d",
+        [0, 0, actual_height, actual_width],
+        (250, 250, 250),
+        0,
+    )
 
     draw_shape(
         draw,
         "diamond",
-        [
-            center_x - width // 2,
-            center_y - height // 2,
-            center_x + width // 2,
-            center_y + width // 2,
-        ],
+        [outer_border, outer_border, outer_border + height, outer_border + width],
         (0, 0, 0),
         0,
     )
-
-    draw_shape(
+    draw_centered_shape(
         draw,
         "diamond",
-        [
-            center_x - width // 2 + border_width,
-            center_y - height // 2 + border_width,
-            center_x + width // 2 - border_width,
-            center_y + width // 2 - border_width,
-        ],
-        color,
-        0,
+        bbox=[outer_border, outer_border, width + outer_border, height + outer_border],
+        bbox_padding=border_width,
+        color=color,
     )
 
-    draw_shape(
+    draw_centered_shape(
         draw,
         "circle",
-        [
-            center_x - circle_radius_outer,
-            center_y - circle_radius_outer,
-            center_x + circle_radius_outer,
-            center_y + circle_radius_outer,
-        ],
-        (0, 0, 0),
-        0,
+        bbox=[center_x, center_y, center_x, center_y],
+        bbox_padding=-circle_radius_outer,
+        color=(0, 0, 0),
     )
-    draw_shape(
+    draw_centered_shape(
         draw,
         "neg-circle",
-        [
-            center_x - circle_radius_inner,
-            center_y - circle_radius_inner,
-            center_x + circle_radius_inner,
-            center_y + circle_radius_inner,
-        ],
-        (120, 0, 0),
-        0,
+        bbox=[center_x, center_y, center_x, center_y],
+        bbox_padding=-circle_radius_inner,
+        color=(120, 0, 0),
     )
 
-    draw_shape(
-        draw,
-        "circle",
-        [
-            center_x - cue_outer_radius,
-            height - cue_outer_radius,
-            center_x + cue_outer_radius,
-            height + cue_outer_radius,
-        ],
-        (0, 0, 0),
-        0,
-    )
-    draw_shape(
-        draw,
-        "circle",
-        [
-            center_x - cue_outer_radius + cue_inner_width,
-            height - cue_outer_radius + cue_inner_width,
-            center_x + cue_outer_radius - cue_inner_width,
-            height + cue_outer_radius - cue_inner_width,
-        ],
-        color,
-        0,
-    )
-
-    if up:
-        return np.array(pattern)[::-1, :] / 255
+    if left:
+        pattern = pattern.transpose(Image.ROTATE_90)
     else:
-        return np.array(pattern) / 255
+        pattern = pattern.transpose(Image.ROTATE_270)
+
+    return np.array(pattern) / 255
 
 
-def posner_target():
-    pattern = Image.new("RGBA", (100, 100), (0, 0, 0, 0))
+def posner_target(target=True):
+    pattern = Image.new("RGBA", (151, 151), (0, 0, 0, 0))
     draw = ImageDraw.Draw(pattern)
 
-    draw_shape(draw, "circle", [0, 0, 100, 100], (75, 75, 75), 0)
-    draw_shape(draw, "neg-circle", [10, 10, 90, 90], (0, 0, 0, 0), 0)
+    draw_shape(draw, "diamond", [0, 0, 150, 150], color=(0, 0, 0), padding=0)
+
+    if target:
+        draw_shape(
+            draw, "neg-hbar_85_100", [0, 0, 150, 150], color=(0, 0, 0), padding=0
+        )
 
     return np.array(pattern)[::-1, :] / 255

--- a/rewardgym/psychopy_render/default_images.py
+++ b/rewardgym/psychopy_render/default_images.py
@@ -57,6 +57,7 @@ def fixation_cross(
     border_width=10,
     circle_radius_outer=20,
     circle_radius_inner=15,
+    kind=None,
 ):
     pattern = Image.new("RGBA", (height + 1, width + 1), (0, 0, 0, 0))
     draw = ImageDraw.Draw(pattern)
@@ -68,6 +69,16 @@ def fixation_cross(
     draw_centered_shape(
         draw, "diamond", [0, 0, height, width], border_width, color=color
     )
+
+    if kind == "win":
+        draw_centered_shape(
+            draw, "halfdiamond_u", [0, 0, height, width], border_width, color=win_color
+        )
+    elif kind == "lose":
+        draw_centered_shape(
+            draw, "halfdiamond_d", [0, 0, height, width], border_width, color=lose_color
+        )
+
     draw_centered_shape(
         draw,
         "circle",
@@ -91,85 +102,42 @@ def win_cross(
     height=150,
     width=150,
     color=(150, 150, 150),
-    cross_color=win_color,
     border_width=10,
     circle_radius_outer=20,
     circle_radius_inner=15,
 ):
-    pattern = Image.new("RGBA", (height + 1, width + 1), (0, 0, 0, 0))
-    draw = ImageDraw.Draw(pattern)
-
-    center_x = width // 2
-    center_y = height // 2
-
-    draw_shape(draw, "diamond", [0, 0, height, width], (0, 0, 0), 0)
-    draw_centered_shape(
-        draw, "diamond", [0, 0, height, width], border_width, color=color
+    win_c = fixation_cross(
+        height=height,
+        width=width,
+        color=color,
+        border_width=border_width,
+        circle_radius_inner=circle_radius_inner,
+        circle_radius_outer=circle_radius_outer,
+        kind="win",
     )
 
-    draw_centered_shape(
-        draw, "halfdiamond_u", [0, 0, height, width], border_width, color=cross_color
-    )
-
-    draw_centered_shape(
-        draw,
-        "circle",
-        bbox=[center_x, center_y, center_x, center_y],
-        bbox_padding=-circle_radius_outer,
-        color=(0, 0, 0),
-    )
-    draw_centered_shape(
-        draw,
-        "neg-circle",
-        bbox=[center_x, center_y, center_x, center_y],
-        bbox_padding=-circle_radius_inner,
-        color=(120, 0, 0),
-    )
-    win_cross = np.array(pattern) / 255
-
-    return win_cross
+    return win_c
 
 
 def lose_cross(
     height=150,
     width=150,
     color=(150, 150, 150),
-    cross_color=lose_color,
     border_width=10,
     circle_radius_outer=20,
     circle_radius_inner=15,
 ):
-    pattern = Image.new("RGBA", (height + 1, width + 1), (0, 0, 0, 0))
-    draw = ImageDraw.Draw(pattern)
-
-    center_x = width // 2
-    center_y = height // 2
-
-    draw_shape(draw, "diamond", [0, 0, height, width], (0, 0, 0), 0)
-    draw_centered_shape(
-        draw, "diamond", [0, 0, height, width], border_width, color=color
-    )
-    draw_centered_shape(
-        draw, "halfdiamond_u", [0, 0, height, width], border_width, color=cross_color
+    lose_c = fixation_cross(
+        height=height,
+        width=width,
+        color=color,
+        border_width=border_width,
+        circle_radius_inner=circle_radius_inner,
+        circle_radius_outer=circle_radius_outer,
+        kind="lose",
     )
 
-    draw_centered_shape(
-        draw,
-        "circle",
-        bbox=[center_x, center_y, center_x, center_y],
-        bbox_padding=-circle_radius_outer,
-        color=(0, 0, 0),
-    )
-    draw_centered_shape(
-        draw,
-        "neg-circle",
-        bbox=[center_x, center_y, center_x, center_y],
-        bbox_padding=-circle_radius_inner,
-        color=(120, 0, 0),
-    )
-    lose_cross = np.array(pattern) / 255
-
-    return lose_cross
+    return lose_c
 
 
 def zero_cross(
@@ -248,6 +216,8 @@ def gonogo_probe(
     circle_radius_outer=20,
     circle_radius_inner=15,
     outer_border=10,
+    under_shape="diamond",
+    return_pattern=False,
 ):
     # left bottom right top
     pattern = Image.new(
@@ -262,7 +232,7 @@ def gonogo_probe(
 
     draw_shape(
         draw,
-        "diamond",
+        under_shape,
         [0, 0, height + outer_border * 2, width + outer_border * 2],
         (250, 250, 250),
         0,
@@ -297,9 +267,12 @@ def gonogo_probe(
         bbox_padding=-circle_radius_inner,
         color=(120, 0, 0),
     )
-    probe = np.array(pattern) / 255
 
-    return probe
+    if return_pattern:
+        return pattern
+    else:
+        probe = np.array(pattern) / 255
+        return probe
 
 
 def generate_stimulus_properties(
@@ -433,55 +406,16 @@ def posner_cue(
     outer_border=10,
     left=True,
 ):
-    actual_height = height + outer_border * 2
-    actual_width = width + outer_border * 2
-
-    pattern = Image.new(
-        "RGBA",
-        (actual_height + 1, actual_width + 1),
-        (0, 0, 0, 0),
-    )
-    draw = ImageDraw.Draw(pattern)
-
-    center_x = actual_width // 2
-    center_y = actual_height // 2
-
-    draw_shape(
-        draw,
-        "halfdiamond_d",
-        [0, 0, actual_height, actual_width],
-        (250, 250, 250),
-        0,
-    )
-
-    draw_shape(
-        draw,
-        "diamond",
-        [outer_border, outer_border, outer_border + height, outer_border + width],
-        (0, 0, 0),
-        0,
-    )
-    draw_centered_shape(
-        draw,
-        "diamond",
-        bbox=[outer_border, outer_border, width + outer_border, height + outer_border],
-        bbox_padding=border_width,
+    pattern = gonogo_probe(
+        height=height,
+        width=width,
         color=color,
-    )
-
-    draw_centered_shape(
-        draw,
-        "circle",
-        bbox=[center_x, center_y, center_x, center_y],
-        bbox_padding=-circle_radius_outer,
-        color=(0, 0, 0),
-    )
-    draw_centered_shape(
-        draw,
-        "neg-circle",
-        bbox=[center_x, center_y, center_x, center_y],
-        bbox_padding=-circle_radius_inner,
-        color=(120, 0, 0),
+        border_width=border_width,
+        circle_radius_inner=circle_radius_inner,
+        circle_radius_outer=circle_radius_outer,
+        outer_border=outer_border,
+        under_shape="halfdiamond_u",
+        return_pattern=True,
     )
 
     if left:

--- a/rewardgym/psychopy_render/gonogo.py
+++ b/rewardgym/psychopy_render/gonogo.py
@@ -1,5 +1,6 @@
 from copy import deepcopy
 
+from ..tasks import FULLPOINTS
 from ..utils import check_seed
 from .default_images import (
     STIMULUS_DEFAULTS,
@@ -51,7 +52,7 @@ def get_info_dict(seed=None, key_dict={"space": 0}, external_stimuli=None, **kwa
         image_map, stimuli = external_stimuli
 
     reward_feedback = FeedBackStimulus(
-        1.0, text="{0}", target="reward", name="reward", bar_total=50
+        1.0, text="{0}", target="reward", name="reward", bar_total=FULLPOINTS["gonogo"]
     )
 
     base_stim = ImageStimulus(

--- a/rewardgym/psychopy_render/gonogo.py
+++ b/rewardgym/psychopy_render/gonogo.py
@@ -50,7 +50,9 @@ def get_info_dict(seed=None, key_dict={"space": 0}, external_stimuli=None, **kwa
     else:
         image_map, stimuli = external_stimuli
 
-    reward_feedback = FeedBackStimulus(1.0, text="{0}", target="reward", name="reward")
+    reward_feedback = FeedBackStimulus(
+        1.0, text="{0}", target="reward", name="reward", bar_total=50
+    )
 
     base_stim = ImageStimulus(
         image_paths=[fixation_cross()], duration=0.3, name="fixation", autodraw=True

--- a/rewardgym/psychopy_render/hcp.py
+++ b/rewardgym/psychopy_render/hcp.py
@@ -4,7 +4,9 @@ from .stimuli import ActionStimulus, FeedBackStimulus, ImageStimulus
 
 
 def get_info_dict(seed=None, key_dict={"left": 0, "right": 1}, **kwargs):
-    reward_feedback = FeedBackStimulus(1.0, text="{0}", target="reward", name="reward")
+    reward_feedback = FeedBackStimulus(
+        1.0, text="{0}", target="reward", name="reward", bar_total=13.5
+    )
 
     base_stim_iti = ImageStimulus(
         image_paths=[fixation_cross()],

--- a/rewardgym/psychopy_render/hcp.py
+++ b/rewardgym/psychopy_render/hcp.py
@@ -1,3 +1,4 @@
+from ..tasks import FULLPOINTS
 from .default_images import fixation_cross
 from .special_stimuli import TextWithBorder
 from .stimuli import ActionStimulus, FeedBackStimulus, ImageStimulus
@@ -5,7 +6,7 @@ from .stimuli import ActionStimulus, FeedBackStimulus, ImageStimulus
 
 def get_info_dict(seed=None, key_dict={"left": 0, "right": 1}, **kwargs):
     reward_feedback = FeedBackStimulus(
-        1.0, text="{0}", target="reward", name="reward", bar_total=13.5
+        1.0, text="{0}", target="reward", name="reward", bar_total=FULLPOINTS["hcp"]
     )
 
     base_stim_iti = ImageStimulus(

--- a/rewardgym/psychopy_render/mid.py
+++ b/rewardgym/psychopy_render/mid.py
@@ -4,7 +4,9 @@ from .stimuli import FeedBackStimulus, ImageStimulus
 
 
 def get_info_dict(seed=None, key_dict={"space": 0}, **kwargs):
-    reward_feedback = FeedBackStimulus(2.0, text="{0}", target="reward", name="reward")
+    reward_feedback = FeedBackStimulus(
+        2.0, text="{0}", target="reward", name="reward", bar_total=48
+    )
 
     fix_isi = ImageStimulus(
         image_paths=[fixation_cross()],

--- a/rewardgym/psychopy_render/mid.py
+++ b/rewardgym/psychopy_render/mid.py
@@ -1,3 +1,4 @@
+from ..tasks import FULLPOINTS
 from .default_images import fixation_cross, mid_stimuli
 from .special_stimuli import ActionStimulusTooEarly
 from .stimuli import FeedBackStimulus, ImageStimulus
@@ -5,7 +6,7 @@ from .stimuli import FeedBackStimulus, ImageStimulus
 
 def get_info_dict(seed=None, key_dict={"space": 0}, **kwargs):
     reward_feedback = FeedBackStimulus(
-        2.0, text="{0}", target="reward", name="reward", bar_total=48
+        2.0, text="{0}", target="reward", name="reward", bar_total=FULLPOINTS["mid"]
     )
 
     fix_isi = ImageStimulus(

--- a/rewardgym/psychopy_render/posner.py
+++ b/rewardgym/psychopy_render/posner.py
@@ -1,3 +1,4 @@
+from ..tasks import FULLPOINTS
 from .default_images import fixation_cross, posner_cue, posner_target
 from .special_stimuli import StimuliWithResponse
 from .stimuli import ActionStimulus, FeedBackStimulus, ImageStimulus
@@ -10,7 +11,7 @@ def get_info_dict(seed=None, key_dict={"left": 0, "right": 1}, **kwargs):
         target="reward",
         name="reward",
         position=(0, 150),
-        bar_total=152,
+        bar_total=FULLPOINTS["posner"],
     )
 
     fix = ImageStimulus(

--- a/rewardgym/psychopy_render/posner.py
+++ b/rewardgym/psychopy_render/posner.py
@@ -1,4 +1,5 @@
 from .default_images import fixation_cross, posner_cue, posner_target
+from .special_stimuli import FlipImageStimulus
 from .stimuli import ActionStimulus, FeedBackStimulus, ImageStimulus
 
 
@@ -24,7 +25,7 @@ def get_info_dict(seed=None, key_dict={"left": 0, "right": 1}, **kwargs):
             fix,
             ImageStimulus(
                 image_paths=[img],
-                duration=0.5,
+                duration=0.4,
                 positions=[(0, 0)],
                 name="cue",
             ),
@@ -38,16 +39,19 @@ def get_info_dict(seed=None, key_dict={"left": 0, "right": 1}, **kwargs):
             ),
         ]
 
-    def second_step(img2, image_shift2, to=1):
+    def second_step(img1, img2, image_shift, to=1):
         return [
-            ImageStimulus(
-                duration=0.05,
+            FlipImageStimulus(
+                duration=0.35,
                 image_paths=[
+                    img1,
                     fixation_cross(),
                     img2,
                 ],
-                positions=[(0, 0), (image_shift2, 0)],
+                positions=[(-image_shift, 0), (0, 0), (image_shift, 0)],
                 name="target",
+                seed=seed,
+                flip_dir="horiz",
             ),
             ImageStimulus(
                 image_paths=[fixation_cross()],
@@ -55,7 +59,7 @@ def get_info_dict(seed=None, key_dict={"left": 0, "right": 1}, **kwargs):
                 duration=0.001,
                 name="fixation",
             ),
-            ActionStimulus(duration=1.0, key_dict=key_dict, timeout_action=to),
+            ActionStimulus(duration=2.0, key_dict=key_dict, timeout_action=to),
         ]
 
     final_step = [
@@ -67,10 +71,24 @@ def get_info_dict(seed=None, key_dict={"left": 0, "right": 1}, **kwargs):
 
     info_dict = {
         0: {"psychopy": []},
-        1: {"psychopy": first_step(posner_cue(up=False))},
-        2: {"psychopy": first_step(posner_cue(up=True))},
-        3: {"psychopy": second_step(posner_target(), image_shift2=-500, to=None)},
-        4: {"psychopy": second_step(posner_target(), image_shift2=500, to=None)},
+        1: {"psychopy": first_step(posner_cue(left=True))},
+        2: {"psychopy": first_step(posner_cue(left=False))},
+        3: {
+            "psychopy": second_step(
+                posner_target(target=False),
+                posner_target(target=True),
+                image_shift=-500,
+                to=None,
+            )
+        },
+        4: {
+            "psychopy": second_step(
+                posner_target(target=True),
+                posner_target(target=False),
+                image_shift=500,
+                to=None,
+            )
+        },
         5: {"psychopy": final_step},
         6: {"psychopy": final_step},
     }

--- a/rewardgym/psychopy_render/posner.py
+++ b/rewardgym/psychopy_render/posner.py
@@ -1,5 +1,5 @@
 from .default_images import fixation_cross, posner_cue, posner_target
-from .special_stimuli import FlipImageStimulus
+from .special_stimuli import StimuliWithResponse
 from .stimuli import ActionStimulus, FeedBackStimulus, ImageStimulus
 
 
@@ -41,25 +41,18 @@ def get_info_dict(seed=None, key_dict={"left": 0, "right": 1}, **kwargs):
 
     def second_step(img1, img2, image_shift, to=1):
         return [
-            FlipImageStimulus(
-                duration=0.35,
-                image_paths=[
-                    img1,
-                    fixation_cross(),
-                    img2,
-                ],
-                positions=[(-image_shift, 0), (0, 0), (image_shift, 0)],
-                name="target",
+            StimuliWithResponse(
+                duration=2.0,
+                key_dict=key_dict,
+                name="response",
+                target_name="target",
+                target_duration=0.35,
+                timeout_action=None,
+                positions=((-image_shift, 0), (image_shift, 0)),
+                images=[img1, img2],
+                flip_probability=0.5,
                 seed=seed,
-                flip_dir="horiz",
-            ),
-            ImageStimulus(
-                image_paths=[fixation_cross()],
-                positions=[(0, 0)],
-                duration=0.001,
-                name="fixation",
-            ),
-            ActionStimulus(duration=2.0, key_dict=key_dict, timeout_action=to),
+            )
         ]
 
     final_step = [
@@ -75,16 +68,16 @@ def get_info_dict(seed=None, key_dict={"left": 0, "right": 1}, **kwargs):
         2: {"psychopy": first_step(posner_cue(left=False))},
         3: {
             "psychopy": second_step(
-                posner_target(target=False),
                 posner_target(target=True),
-                image_shift=-500,
+                posner_target(target=False),
+                image_shift=500,
                 to=None,
             )
         },
         4: {
             "psychopy": second_step(
-                posner_target(target=True),
                 posner_target(target=False),
+                posner_target(target=True),
                 image_shift=500,
                 to=None,
             )

--- a/rewardgym/psychopy_render/posner.py
+++ b/rewardgym/psychopy_render/posner.py
@@ -10,6 +10,7 @@ def get_info_dict(seed=None, key_dict={"left": 0, "right": 1}, **kwargs):
         target="reward",
         name="reward",
         position=(0, 150),
+        bar_total=152,
     )
 
     fix = ImageStimulus(

--- a/rewardgym/psychopy_render/risk_sensitive.py
+++ b/rewardgym/psychopy_render/risk_sensitive.py
@@ -51,7 +51,9 @@ def get_info_dict(
     else:
         image_map, stimuli = external_stimuli
 
-    reward_feedback = FeedBackStimulus(1.0, text="{0}", target="reward", name="reward")
+    reward_feedback = FeedBackStimulus(
+        1.0, text="{0}", target="reward", name="reward", bar_total=5150
+    )
 
     base_stim = ImageStimulus(
         image_paths=[fixation_cross()], duration=0.1, name=None, autodraw=True

--- a/rewardgym/psychopy_render/risk_sensitive.py
+++ b/rewardgym/psychopy_render/risk_sensitive.py
@@ -1,5 +1,6 @@
 from copy import deepcopy
 
+from ..tasks import FULLPOINTS
 from ..utils import check_seed
 from .default_images import (
     STIMULUS_DEFAULTS,
@@ -52,7 +53,11 @@ def get_info_dict(
         image_map, stimuli = external_stimuli
 
     reward_feedback = FeedBackStimulus(
-        1.0, text="{0}", target="reward", name="reward", bar_total=5150
+        1.0,
+        text="{0}",
+        target="reward",
+        name="reward",
+        bar_total=FULLPOINTS["risk-sensitive"],
     )
 
     base_stim = ImageStimulus(

--- a/rewardgym/psychopy_render/special_stimuli.py
+++ b/rewardgym/psychopy_render/special_stimuli.py
@@ -61,7 +61,7 @@ class ActionStimulusTooEarly(ActionStimulus):
         self.name_tooearly = name_tooearly
         self.text_tooearly = text_tooearly
 
-    def setup(self, win: Window = None, **kwargs):
+    def _setup(self, win: Window = None, **kwargs):
         """
         Does not need a special setup, including the function, to make easy looping possible.
 
@@ -155,7 +155,7 @@ class ConditionBasedDisplay(BaseStimulus):
         self.image_shift = image_shift
         self.with_action = with_action
 
-    def setup(self, win, **kwargs):
+    def _setup(self, win, **kwargs):
         self.image_dict = {}
 
         for kk in self.image_map.keys():
@@ -273,7 +273,7 @@ class TwoStimuliWithResponseAndSelection(ActionStimulus):
         self.flip_probability = flip_probability
         self.seed = check_seed(seed)
 
-    def setup(self, win, **kwargs):
+    def _setup(self, win, **kwargs):
         self.image_class = []
         for img, pos in zip(self.images, self.positions):
             if isinstance(img, str):
@@ -529,7 +529,7 @@ class StimuliWithResponse(ActionStimulus):
         self.flip_dir = flip_dir
         self.rng = check_seed(seed)
 
-    def setup(self, win, **kwargs):
+    def _setup(self, win, **kwargs):
         self.imageStims = []
         for img, pos in zip(self.images, self.positions):
             if isinstance(img, str):

--- a/rewardgym/psychopy_render/special_stimuli.py
+++ b/rewardgym/psychopy_render/special_stimuli.py
@@ -562,10 +562,10 @@ class FlipImageStimulus(ImageStimulus):
         # So that images are drawn on top
         for ii in self.imageStims:
             ii.autoDraw = True
-            if self.flip_dir == "horiz":
-                ii.flipHoriz = flip
-            elif self.flip_dir == "vert":
-                ii.flipVert = flip
+            if self.flip_dir == "vert":
+                ii.flip = [flip, False]
+            elif self.flip_dir == "horiz":
+                ii.flip = [False, flip]
 
         win.flip()
 

--- a/rewardgym/psychopy_render/special_stimuli.py
+++ b/rewardgym/psychopy_render/special_stimuli.py
@@ -340,7 +340,10 @@ class TwoStimuliWithResponseAndSelection(ActionStimulus):
             onset=stim_onset,
         )
 
-        response_key, remaining = self._simulate_response(logger, key, rt)
+        response_window_onset = logger.get_time()
+        response_key, remaining = self._simulate_response(
+            logger, key, rt, response_window_onset=response_window_onset
+        )
 
         stim_onset = logger.get_time()
 

--- a/rewardgym/psychopy_render/stimuli.py
+++ b/rewardgym/psychopy_render/stimuli.py
@@ -429,13 +429,15 @@ class ActionStimulus(BaseStimulus):
         rt: float = None,
         **kwargs,
     ):
-        response = self._simulate_response(logger, key, rt)
+        response_window_onset = logger.get_time()
+        response = self._simulate_response(
+            logger, key, rt, response_window_onset=response_window_onset
+        )
 
         return response
 
-    def _simulate_response(self, logger, key, rt):
+    def _simulate_response(self, logger, key, rt, response_window_onset):
         response_key, rt = logger.key_strokes(key, rt)
-        response_window_onset = logger.get_time()
 
         if rt is None:
             warnings.warn(

--- a/rewardgym/psychopy_render/stimuli.py
+++ b/rewardgym/psychopy_render/stimuli.py
@@ -601,7 +601,6 @@ class FeedBackStimulus(BaseStimulus):
                 units="pix",
             )
 
-            self.point_bar.autoDraw = True
             self.total_reward_ind = Rect(
                 win=win,
                 name=self.name + "total_indicator",
@@ -612,6 +611,27 @@ class FeedBackStimulus(BaseStimulus):
                 lineWidth=0,
                 pos=(-self.bar_length // 2, 350),
             )
+
+            self.text_left = TextStim(
+                win=win,
+                name="label_left",
+                text=self.bar_labels["left"],
+                color="white",
+                height=25,
+                pos=(-self.bar_length // 2 - 40, 350),
+            )
+            self.text_right = TextStim(
+                win=win,
+                name="label_right",
+                text=self.bar_labels["right"],
+                color="white",
+                height=25,
+                pos=(self.bar_length // 2 + 40, 350),
+            )
+
+            self.text_right.setAutoDraw(True)
+            self.text_left.setAutoDraw(True)
+            self.point_bar.autoDraw = True
             self.total_reward_ind.autoDraw = True
 
         self.feedback_image = {}

--- a/rewardgym/psychopy_render/two_step.py
+++ b/rewardgym/psychopy_render/two_step.py
@@ -39,9 +39,10 @@ def twostep_stimuli(random_state, stim_defaults=STIMULUS_DEFAULTS):
                 i for i in stim_defaults["shapes"] if i != st_p["shapes"]
             ]
 
+        height = 375 if n == 0 else 250
         stim_properties[n] = stimulus_properties
         stim_set[n] = [
-            make_card_stimulus(stim_properties[n][k], width=250, height=250)
+            make_card_stimulus(stim_properties[n][k], width=250, height=height)
             for k in range(2)
         ]
 

--- a/rewardgym/psychopy_render/two_step.py
+++ b/rewardgym/psychopy_render/two_step.py
@@ -57,7 +57,9 @@ def get_info_dict(
     else:
         stim_set, stimuli = external_stimuli
 
-    reward_feedback = FeedBackStimulus(1.0, text="{0}", target="reward", name="reward")
+    reward_feedback = FeedBackStimulus(
+        1.0, text="{0}", target="reward", name="reward", bar_total=100
+    )
 
     fix = ImageStimulus(
         image_paths=[fixation_cross()],

--- a/rewardgym/psychopy_render/two_step.py
+++ b/rewardgym/psychopy_render/two_step.py
@@ -2,6 +2,7 @@ from copy import deepcopy
 
 import numpy as np
 
+from ..tasks import FULLPOINTS
 from ..utils import check_seed
 from .default_images import (
     STIMULUS_DEFAULTS,
@@ -58,7 +59,11 @@ def get_info_dict(
         stim_set, stimuli = external_stimuli
 
     reward_feedback = FeedBackStimulus(
-        1.0, text="{0}", target="reward", name="reward", bar_total=100
+        1.0,
+        text="{0}",
+        target="reward",
+        name="reward",
+        bar_total=FULLPOINTS["two-step"],
     )
 
     fix = ImageStimulus(

--- a/rewardgym/tasks/__init__.py
+++ b/rewardgym/tasks/__init__.py
@@ -1,3 +1,12 @@
 from .utils import get_configs, get_env, get_task
 
-__all__ = ["get_configs", "get_env", "get_task"]
+FULLPOINTS = {
+    "posner": 152,
+    "mid": 48,
+    "hcp": 13.5,
+    "risk-sensitive": 5150,
+    "two-step": 100,
+    "gonogo": 50,
+}
+
+__all__ = ["get_configs", "get_env", "get_task", "FULLPOINTS"]

--- a/rewardgym/tasks/posner.py
+++ b/rewardgym/tasks/posner.py
@@ -32,8 +32,8 @@ def get_posner(
         {
             "position": {
                 0: "selection",
-                1: "cue-1",
-                2: "cue-2",
+                1: "cue-left",
+                2: "cue-right",
                 3: "target-left",
                 4: "target-right",
                 5: "win",
@@ -98,81 +98,46 @@ def generate_posner_configs(stimulus_set: str = "1"):
     seed = check_seed(int(stimulus_set))
 
     condition_dict = {
-        "cue-1-target-left": {0: {0: 1}, 1: {0: 3}},
-        "cue-1-target-right": {0: {0: 1}, 1: {0: 4}},
-        "cue-2-target-right": {0: {0: 2}, 2: {0: 4}},
-        "cue-2-target-left": {0: {0: 2}, 2: {0: 3}},
+        "cue-left-target-left": {0: {0: 1}, 1: {0: 3}},
+        "cue-left-target-right": {0: {0: 1}, 1: {0: 4}},
+        "cue-right-target-right": {0: {0: 2}, 2: {0: 4}},
+        "cue-right-target-left": {0: {0: 2}, 2: {0: 3}},
     }
 
     # 20 trials in each condition template
-    condition_template_70_30 = (
-        ["cue-1-target-left"] * 7
-        + ["cue-1-target-right"] * 3
-        + ["cue-2-target-right"] * 7
-        + ["cue-2-target-left"] * 3
-    )
-
-    condition_template_90_10 = (
-        ["cue-1-target-left"] * 9
-        + ["cue-1-target-right"] * 1
-        + ["cue-2-target-right"] * 9
-        + ["cue-2-target-left"] * 1
-    )
-
-    condition_template_10_90 = (
-        ["cue-1-target-left"] * 1
-        + ["cue-1-target-right"] * 9
-        + ["cue-2-target-right"] * 1
-        + ["cue-2-target-left"] * 9
-    )
-
-    condition_template_30_70 = (
-        ["cue-1-target-left"] * 3
-        + ["cue-1-target-right"] * 7
-        + ["cue-2-target-right"] * 3
-        + ["cue-2-target-left"] * 7
+    condition_template_80_20 = (
+        ["cue-left-target-left"] * 8
+        + ["cue-left-target-right"] * 2
+        + ["cue-right-target-right"] * 8
+        + ["cue-right-target-left"] * 2
     )
 
     iti_template = [1, 1.5, 2, 2.5] * 5
     isi_template = [0.4, 0.6] * 10
 
-    n_blocks_condition = 2
+    n_blocks_condition = 8
 
-    dont_follow_dict = {
-        0: ["cue-1-target-left", "cue-2-target-right"],
-        2: ["cue-1-target-left", "cue-2-target-right"],
-        1: ["cue-1-target-right", "cue2-target-left"],
-        3: ["cue-1-target-right", "cue2-target-left"],
-    }
-    condition_order = seed.permutation([0, 1, 2, 3])
-    condition_assign = {
-        0: condition_template_10_90,
-        1: condition_template_90_10,
-        2: condition_template_30_70,
-        3: condition_template_70_30,
-    }
+    dont_follow = ["cue-left-target-right", "cue-right-target-left"]
 
     conditions, isi, iti = [], [], []
-    for co in condition_order:
-        for cn in range(n_blocks_condition):
-            reject = True
 
-            while reject:
-                condition_template = seed.choice(
-                    a=condition_assign[co], size=20, replace=False
-                ).tolist()
+    for cn in range(n_blocks_condition):
+        reject = True
 
-                check = check_conditions_not_following(
-                    condition_template, dont_follow_dict[co], 2
-                )
+        while reject:
+            condition_template = seed.choice(
+                a=condition_template_80_20, size=20, replace=False
+            ).tolist()
 
-                if check and (
-                    len(conditions) == 0 or conditions[-1] != condition_template[0]
-                ):
-                    conditions.extend(condition_template)
-                    isi.extend(seed.permutation(isi_template).tolist())
-                    iti.extend(seed.permutation(iti_template).tolist())
-                    reject = False
+            check = check_conditions_not_following(condition_template, dont_follow, 2)
+
+            if check and (
+                len(conditions) == 0 or conditions[-1] != condition_template[0]
+            ):
+                conditions.extend(condition_template)
+                isi.extend(seed.permutation(isi_template).tolist())
+                iti.extend(seed.permutation(iti_template).tolist())
+                reject = False
 
     config = {
         "name": "posner",
@@ -184,7 +149,7 @@ def generate_posner_configs(stimulus_set: str = "1"):
         "ntrials": len(conditions),
         "update": ["isi", "iti"],
         "add_remainder": True,
-        "breakpoints": [59, 119],
+        "breakpoints": [79],
         "break_duration": 45,
     }
 

--- a/rewardgym/tasks/risk_sensitive.py
+++ b/rewardgym/tasks/risk_sensitive.py
@@ -330,6 +330,12 @@ def generate_risk_sensitive_configs(stimulus_set: str = "1"):
                     ]
                 )
                 and check_conditions_not_following(conditions_proposal, test_trials)
+                and all(
+                    [
+                        check_conditions_not_following(conditions_proposal, [jj])
+                        for jj in risky_non_equal_ev + risky_equal_ev
+                    ]
+                )
             )
 
         conditions.extend(conditions_proposal)

--- a/rewardgym_psychopy.py
+++ b/rewardgym_psychopy.py
@@ -7,6 +7,7 @@ from rewardgym import get_configs, get_env
 from rewardgym.psychopy_core import run_task
 from rewardgym.psychopy_extras import set_up_experiment
 from rewardgym.psychopy_render import ExperimentLogger, get_psychopy_info
+from rewardgym.tasks import FULLPOINTS
 
 if __name__ == "__main__":
     (
@@ -97,10 +98,11 @@ if __name__ == "__main__":
     run_task(env=env, win=win, logger=Logger, settings=settings, n_episodes=None)
 
     win.to_Draw = []
+    proportion = max([min([env.cumulative_reward / FULLPOINTS[task], 1.0]), 0])
 
     final = visual.TextStim(
         win=win,
-        text=f"You are done!\nThank you!\nYou earned {env.cumulative_reward} points!",
+        text=f"You are done!\nThank you!\nYou got {env.cumulative_reward} points!\nWhich is a score of {proportion:4.2f} %!",
         color=[1, 1, 1],
         pos=(0, 150),
         height=24,


### PR DESCRIPTION
<!-- Write all of the issues that are linked to this pull request. -->
<!-- If this PR is enough to close them you can write something like "Closes #314 and closes #42" -->
<!-- If you just want to reference them without closing them, you can add something like "References #112" -->
Closes #

<!-- Add a short description of the PR content here-->
This became again a too long PR. A lot of display changes.

## Proposed Changes
<!-- List major points of changes here, so that the reviewers can have a bit more context while looking at your work! -->
  - Changes to posner task, it is now closer to original version
  - Editing of instructions
  - Changes to instruction display
  - Changed the ordering in risk-sensitive task
  - Cleaned up display stimuli
  - Added a bar that fills up for points.
  - Added a marker to stimuli, to check if they've been setup, to avoid multi drawing.

## Change Type
<!-- Indicate the type of change you think your pull request is -->
- [ ] `bugfix` (+0.0.1)
- [x] `minor` (+0.1.0)
- [ ] `major`  (+1.0.0)
- [ ] `refactoring` (no version update)
- [ ] `test` (no version update)
- [ ] `infrastructure` (no version update)
- [ ] `documentation` (no version update)
- [ ] `other`

## Checklist before review
<!-- You're invited to open a draft PR ASAP, but before marking it "ready for review", check that you have done the following: -->
- [x] I added everything I wanted to add to this PR.
- [ ] \[Code or tests only\] I wrote/updated the necessary docstrings.
- [ ] \[Code or tests only\] I ran and passed tests locally.
- [ ] \[Documentation only\] I built the docs locally.
- [ ] My contribution is harmonious with the rest of the code: I'm not introducing repetitions.
- [x] My code respects the adopted style, especially linting conventions.
- [ ] The title of this PR is explanatory on its own, enough to be understood as part of a changelog.
- [ ] I added or indicated the right labels.
